### PR TITLE
Streaming - Experimental Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
       - checkout  # check out source code to working directory
-      - run: wget https://github.com/nats-io/gnatsd/releases/download/v1.4.1/gnatsd-v1.4.1-linux-amd64.zip
+      - run: wget https://github.com/nats-io/nats-server/releases/download/v1.4.1/gnatsd-v1.4.1-linux-amd64.zip
       - run: unzip gnatsd-v1.4.1-linux-amd64.zip
+      - run: wget https://github.com/nats-io/nats-streaming-server/releases/download/v0.14.1/nats-streaming-server-v0.14.1-linux-amd64.zip
+      - run: unzip nats-streaming-server-v0.14.1-linux-amd64.zip
       - run:
-          command: ./gnatsd-v1.4.1-linux-amd64/gnatsd
+          command: ./nats-streaming-server-v0.14.1-linux-amd64/nats-streaming-server
           background: true
       - run:
           command: ./gnatsd-v1.4.1-linux-amd64/gnatsd -p 4223 --user bob --pass alice

--- a/lib/gnat/streaming/client.ex
+++ b/lib/gnat/streaming/client.ex
@@ -1,0 +1,107 @@
+defmodule Gnat.Streaming.Client do
+  use GenServer
+  require Logger
+  alias Gnat.Streaming.Protocol
+
+  def start_link(settings, options \\ []) do
+    GenServer.start_link(__MODULE__, settings, options)
+  end
+
+  @spec pub(GenServer.server, String.t, binary(), keyword()) :: :ok | {:error, term()}
+  def pub(streaming_client, subject, payload, options \\ []) do
+    reply_to = Keyword.get(options, :reply_to)
+    guid = Keyword.get(options, :guid) || nuid()
+    with {:ok, client_id, pub_prefix, connection_pid} <- GenServer.call(streaming_client, :pub_info),
+         pub_subject <- "#{pub_prefix}.me",
+         pub_msg <- encode_pub_msg(subject, payload, guid, reply_to, client_id),
+         {:ok, %{body: pb}} <- Gnat.request(connection_pid, pub_subject, pub_msg) do
+      case Protocol.PubAck.decode(pb) do
+        %Protocol.PubAck{error: ""} -> :ok
+        %Protocol.PubAck{error: err} -> {:error, err}
+      end
+    end
+  end
+
+  @impl GenServer
+  def init(settings) do
+    Process.flag(:trap_exit, true)
+    send self(), :connect
+    state = %{
+      client_id: Map.fetch!(settings, :client_id),
+      conn_id: Map.get(settings, :conn_id) || nuid(),
+      connection_name: Map.fetch!(settings, :connection_name),
+      connection_pid: nil,
+      connect_response: nil,
+      status: :disconnected,
+    }
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:pub_info, _from, %{status: :connected}=state) do
+    pub_info = {:ok, state.client_id, state.connect_response.pubPrefix, state.connection_pid}
+    {:reply, pub_info, state}
+  end
+
+  @impl GenServer
+  def handle_info(:connect, %{connection_name: name}=state) do
+    case Process.whereis(name) do
+      nil ->
+        Process.send_after(self(), :connect, 2_000)
+        {:noreply, state}
+      connection_pid ->
+        _ref = Process.monitor(connection_pid)
+        heartbeat_subject = "#{state.client_id}.#{state.conn_id}.heartbeat"
+        req = Protocol.ConnectRequest.new(clientID: state.client_id, connID: state.conn_id, heartbeatInbox: heartbeat_subject) |> Protocol.ConnectRequest.encode()
+        {:ok, _sid} = Gnat.sub(connection_pid, self(), heartbeat_subject)
+        case Gnat.request(connection_pid, "_STAN.discover.test-cluster", req) do
+          {:ok, %{body: msg}} ->
+            msg = Protocol.ConnectResponse.decode(msg) |> IO.inspect
+            {:noreply, %{state | status: :connected, connection_pid: connection_pid, connect_response: msg}}
+          {:error, reason} ->
+            Process.send_after(self(), :connect, 2_000)
+            Logger.error("Failed to connect to NATS Streaming server: #{inspect(reason)}")
+            {:noreply, state}
+        end
+    end
+  end
+  # receive heartbeat messages and respond
+  def handle_info({:msg, %{body: "", reply_to: reply_to}}, state) do
+    Gnat.pub(state.connection_pid, reply_to, "")
+    {:noreply, state}
+  end
+  # the connection has died, we need to reset our state and try to reconnect
+  def handle_info({:DOWN, _ref, :process, connection_pid, reason}, %{connection_pid: connection_pid}=state) do
+    Logger.info("connection down #{inspect(reason)}")
+    Process.send_after(self(), :connect, 2_000)
+    {:noreply, %{state | status: :disconnected, connection_pid: nil, connect_response: nil}}
+  end
+  # Ignore DOWN and task result messages from the spawned tasks
+  def handle_info({:DOWN, _ref, :process, _task_pid, _reason}, state), do: {:noreply, state}
+  def handle_info({ref, _result}, state) when is_reference(ref), do: {:noreply, state}
+
+  def handle_info(other, state) do
+    Logger.error "#{__MODULE__} received unexpected message #{inspect other}"
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def terminate(:shutdown, _state) do
+    # TODO Send CloseRequest https://nats.io/documentation/streaming/nats-streaming-protocol/#CLOSEREQ
+  end
+  def terminate(reason, _state) do
+    Logger.error "#{__MODULE__} unexpected shutdown #{inspect reason}"
+  end
+
+  defp encode_pub_msg(subject, payload, guid, reply_to, client_id) do
+    Protocol.PubMsg.new(
+      clientID: client_id,
+      guid: guid,
+      subject: subject,
+      data: payload,
+      reply: reply_to
+    ) |> Protocol.PubMsg.encode()
+  end
+
+  defp nuid, do: :crypto.strong_rand_bytes(12) |> Base.encode64
+end

--- a/lib/gnat/streaming/client.ex
+++ b/lib/gnat/streaming/client.ex
@@ -124,7 +124,7 @@ defmodule Gnat.Streaming.Client do
 
     case Gnat.request(state.connection_pid, "_STAN.discover.test-cluster", req) do
       {:ok, %{body: msg}} ->
-        msg = Protocol.ConnectResponse.decode(msg) |> IO.inspect
+        msg = Protocol.ConnectResponse.decode(msg)
         actions = [{:next_event, :internal, {:connect_response, msg}}]
         {:keep_state_and_data, actions}
       {:error, reason} ->

--- a/lib/gnat/streaming/message.ex
+++ b/lib/gnat/streaming/message.ex
@@ -1,0 +1,16 @@
+defmodule Gnat.Streaming.Message do
+  @enforce_keys [:ack_subject, :connection_pid, :data, :redelivered, :reply, :sequence, :subject, :timestamp]
+  defstruct [:ack_subject, :connection_pid, :data, :redelivered, :reply, :sequence, :subject, :timestamp]
+
+  alias Gnat.Streaming.Protocol.Ack
+
+  def ack(%__MODULE__{}=message) do
+    %__MODULE__{
+      ack_subject: ack_subject,
+      connection_pid: pid,
+      sequence: sequence,
+      subject: subject} = message
+    ack = Ack.new(subject: subject, sequence: sequence) |> Ack.encode()
+    Gnat.pub(pid, ack_subject, ack)
+  end
+end

--- a/lib/gnat/streaming/protocol.pb.ex
+++ b/lib/gnat/streaming/protocol.pb.ex
@@ -1,7 +1,7 @@
 # based on https://github.com/nats-io/go-nats-streaming/blob/3e2ff0719c7a6219b4e791e19c782de98c701f4a/pb/protocol.proto
 # version 0.4.2 of go-nats-streaming
 # Generated using https://github.com/tony612/protobuf-elixir#generate-elixir-code and then changed the namespace from Pb.* to Gnat.StreamingProtocol.*
-defmodule Gnat.StreamingProtocol.PubMsg do
+defmodule Gnat.Streaming.Protocol.PubMsg do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -25,7 +25,7 @@ defmodule Gnat.StreamingProtocol.PubMsg do
   field :sha256, 10, type: :bytes
 end
 
-defmodule Gnat.StreamingProtocol.PubAck do
+defmodule Gnat.Streaming.Protocol.PubAck do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -39,7 +39,7 @@ defmodule Gnat.StreamingProtocol.PubAck do
   field :error, 2, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.MsgProto do
+defmodule Gnat.Streaming.Protocol.MsgProto do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -63,7 +63,7 @@ defmodule Gnat.StreamingProtocol.MsgProto do
   field :CRC32, 10, type: :uint32
 end
 
-defmodule Gnat.StreamingProtocol.Ack do
+defmodule Gnat.Streaming.Protocol.Ack do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -77,7 +77,7 @@ defmodule Gnat.StreamingProtocol.Ack do
   field :sequence, 2, type: :uint64
 end
 
-defmodule Gnat.StreamingProtocol.ConnectRequest do
+defmodule Gnat.Streaming.Protocol.ConnectRequest do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -99,7 +99,7 @@ defmodule Gnat.StreamingProtocol.ConnectRequest do
   field :pingMaxOut, 6, type: :int32
 end
 
-defmodule Gnat.StreamingProtocol.ConnectResponse do
+defmodule Gnat.Streaming.Protocol.ConnectResponse do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -143,7 +143,7 @@ defmodule Gnat.StreamingProtocol.ConnectResponse do
   field :publicKey, 100, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.Ping do
+defmodule Gnat.Streaming.Protocol.Ping do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -155,7 +155,7 @@ defmodule Gnat.StreamingProtocol.Ping do
   field :connID, 1, type: :bytes
 end
 
-defmodule Gnat.StreamingProtocol.PingResponse do
+defmodule Gnat.Streaming.Protocol.PingResponse do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -167,7 +167,7 @@ defmodule Gnat.StreamingProtocol.PingResponse do
   field :error, 1, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.SubscriptionRequest do
+defmodule Gnat.Streaming.Protocol.SubscriptionRequest do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -203,12 +203,12 @@ defmodule Gnat.StreamingProtocol.SubscriptionRequest do
   field :maxInFlight, 5, type: :int32
   field :ackWaitInSecs, 6, type: :int32
   field :durableName, 7, type: :string
-  field :startPosition, 10, type: Gnat.StreamingProtocol.StartPosition, enum: true
+  field :startPosition, 10, type: Gnat.Streaming.Protocol.StartPosition, enum: true
   field :startSequence, 11, type: :uint64
   field :startTimeDelta, 12, type: :int64
 end
 
-defmodule Gnat.StreamingProtocol.SubscriptionResponse do
+defmodule Gnat.Streaming.Protocol.SubscriptionResponse do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -222,7 +222,7 @@ defmodule Gnat.StreamingProtocol.SubscriptionResponse do
   field :error, 3, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.UnsubscribeRequest do
+defmodule Gnat.Streaming.Protocol.UnsubscribeRequest do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -240,7 +240,7 @@ defmodule Gnat.StreamingProtocol.UnsubscribeRequest do
   field :durableName, 4, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.CloseRequest do
+defmodule Gnat.Streaming.Protocol.CloseRequest do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -252,7 +252,7 @@ defmodule Gnat.StreamingProtocol.CloseRequest do
   field :clientID, 1, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.CloseResponse do
+defmodule Gnat.Streaming.Protocol.CloseResponse do
   @moduledoc false
   use Protobuf, syntax: :proto3
 
@@ -264,7 +264,7 @@ defmodule Gnat.StreamingProtocol.CloseResponse do
   field :error, 1, type: :string
 end
 
-defmodule Gnat.StreamingProtocol.StartPosition do
+defmodule Gnat.Streaming.Protocol.StartPosition do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto3
 

--- a/lib/gnat/streaming/subscription.ex
+++ b/lib/gnat/streaming/subscription.ex
@@ -1,0 +1,129 @@
+defmodule Gnat.Streaming.Subscription do
+  @behaviour :gen_statem
+
+  @enforce_keys [:client_name, :subject]
+  defstruct ack_subject: nil,
+            ack_wait_in_sec: 30,
+            client_id: nil,
+            client_name: nil,
+            connection_pid: nil,
+            inbox: nil,
+            max_in_flight: 100,
+            sub_subject: nil,
+            subject: nil
+
+  @type t :: %__MODULE__{
+    ack_subject: String.t,
+    ack_wait_in_sec: non_neg_integer(),
+    client_id: String.t | nil,
+    client_name: atom(),
+    connection_pid: pid() | nil,
+    inbox: String.t | nil,
+    max_in_flight: non_neg_integer(),
+    sub_subject: String.t,
+    subject: String.t
+  }
+
+  require Logger
+  alias Gnat.Streaming.{Client, Protocol}
+
+  def start_link(settings, options \\ []) do
+    :gen_statem.start_link(__MODULE__, settings, options)
+  end
+
+  # Callback Functions
+
+  @impl :gen_statem
+  def callback_mode(), do: :state_functions
+
+  @impl :gen_statem
+  def init(settings) do
+    Process.flag(:trap_exit, true)
+    state = new(settings)
+    {:ok, :disconnected, state, [{:next_event, :internal, :connect}]}
+  end
+
+  @impl :gen_statem
+  @spec terminate(any(), any(), any()) :: :ok | {:error, any()}
+  def terminate(:shutdown, _state, _data) do
+    Logger.error "#{__MODULE__} TODO - I should send an UnsubscribeRequest to notify the broker that I'm going away"
+    # TODO Send CloseRequest https://nats.io/documentation/streaming/nats-streaming-protocol/#UNSUBREQ
+  end
+  def terminate(reason, _state, _data) do
+    Logger.error "#{__MODULE__} unexpected shutdown #{inspect reason}"
+  end
+
+  # Internal State Functions
+
+  @doc false
+  def new(settings) do
+    client_name = Keyword.fetch!(settings, :client_name)
+    subject = Keyword.fetch!(settings, :subject)
+    %__MODULE__{client_name: client_name, subject: subject}
+  end
+
+  @doc false
+  def disconnected(:internal, :connect, %__MODULE__{client_name: client_name}) do
+    client_info = Client.sub_info(client_name)
+    {:keep_state_and_data, [{:next_event, :internal, {:client_info, client_info}}]}
+  end
+  def disconnected({:timeout, :reconnect}, _, state), do: disconnected(:internal, :connect, state)
+  def disconnected(:internal, {:client_info, {:error, _reason}}, _state) do
+    {:keep_state_and_data, [{{:timeout, :reconnect}, 250, :reconnect}]}
+  end
+  def disconnected(:internal, {:client_info, {:ok, client_info}}, %__MODULE__{} = state) do
+    {client_id, sub_subject, connection_pid} = client_info
+    inbox = "#{client_id}.#{state.subject}.INBOX"
+    state = %__MODULE__{state | inbox: inbox, client_id: client_id, connection_pid: connection_pid, sub_subject: sub_subject}
+    actions = [{:next_event, :internal, :monitor_and_listen}]
+    {:next_state, :connected, state, actions}
+  end
+
+  @doc false
+  def connected(:internal, :monitor_and_listen, %__MODULE__{} = state) do
+    _ref = Process.monitor(state.connection_pid)
+    {:ok, _sid} = Gnat.sub(state.connection_pid, self(), state.inbox)
+    {:keep_state_and_data, [{:next_event, :internal, :subscribe}]}
+  end
+  def connected({:timeout, :resubscribe}, _, %__MODULE__{} = state), do: connected(:internal, :subscribe, state)
+  def connected(:internal, :subscribe, %__MODULE__{} = state) do
+    req = Protocol.SubscriptionRequest.new(
+      ackWaitInSecs: state.ack_wait_in_sec,
+      clientID: state.client_id,
+      inbox: state.inbox,
+      maxInFlight: state.max_in_flight,
+      subject: state.subject
+    ) |> Protocol.SubscriptionRequest.encode()
+    case Gnat.request(state.connection_pid, state.sub_subject, req) do
+      {:ok, %{body: msg}} ->
+        msg = Protocol.SubscriptionResponse.decode(msg) |> IO.inspect()
+        actions = [{:next_event, :internal, {:subscription_response, msg}}]
+        {:keep_state_and_data, actions}
+      {:error, reason} ->
+        Logger.error("Failed to subscribe to NATS Streaming server: #{inspect(reason)}")
+        actions = [{{:timeout, :resubscribe}, 1_000, :resubscribe}]
+        {:keep_state_and_data, actions}
+    end
+  end
+  def connected(:internal, {:subscription_response, %Protocol.SubscriptionResponse{} = response}, %__MODULE__{} = state) do
+    if response.error == "" do
+      state = %__MODULE__{state | ack_subject: response.ackInbox}
+      {:next_state, :subscribed, state, []}
+    else
+      Logger.error("Failed to subscribe to NATS Streaming server: #{response.error}")
+      {:keep_state_and_data, [{{:timeout, :resubscribe}, 1_000, :resubscribe}]}
+    end
+  end
+  def connected(:info, {:DOWN, _ref, :process, pid, _reason}, %__MODULE__{connection_pid: pid} = state) do
+    state = %__MODULE__{state | client_id: nil, connection_pid: nil, inbox: nil, sub_subject: nil}
+    actions = [{{:timeout, :reconnect}, 250, :reconnect}]
+    {:next_state, :disconnected, state, actions}
+  end
+
+  @doc false
+  def subscribed(:info, {:DOWN, _ref, :process, pid, _reason}, %__MODULE__{connection_pid: pid} = state) do
+    state = %__MODULE__{state | ack_subject: nil, client_id: nil, connection_pid: nil, inbox: nil, sub_subject: nil}
+    actions = [{{:timeout, :reconnect}, 250, :reconnect}]
+    {:next_state, :disconnected, state, actions}
+  end
+end

--- a/lib/gnat/streaming_protocol.pb.ex
+++ b/lib/gnat/streaming_protocol.pb.ex
@@ -1,0 +1,276 @@
+# based on https://github.com/nats-io/go-nats-streaming/blob/3e2ff0719c7a6219b4e791e19c782de98c701f4a/pb/protocol.proto
+# version 0.4.2 of go-nats-streaming
+# Generated using https://github.com/tony612/protobuf-elixir#generate-elixir-code and then changed the namespace from Pb.* to Gnat.StreamingProtocol.*
+defmodule Gnat.StreamingProtocol.PubMsg do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          clientID: String.t(),
+          guid: String.t(),
+          subject: String.t(),
+          reply: String.t(),
+          data: binary,
+          connID: binary,
+          sha256: binary
+        }
+  defstruct [:clientID, :guid, :subject, :reply, :data, :connID, :sha256]
+
+  field :clientID, 1, type: :string
+  field :guid, 2, type: :string
+  field :subject, 3, type: :string
+  field :reply, 4, type: :string
+  field :data, 5, type: :bytes
+  field :connID, 6, type: :bytes
+  field :sha256, 10, type: :bytes
+end
+
+defmodule Gnat.StreamingProtocol.PubAck do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          guid: String.t(),
+          error: String.t()
+        }
+  defstruct [:guid, :error]
+
+  field :guid, 1, type: :string
+  field :error, 2, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.MsgProto do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          sequence: non_neg_integer,
+          subject: String.t(),
+          reply: String.t(),
+          data: binary,
+          timestamp: integer,
+          redelivered: boolean,
+          CRC32: non_neg_integer
+        }
+  defstruct [:sequence, :subject, :reply, :data, :timestamp, :redelivered, :CRC32]
+
+  field :sequence, 1, type: :uint64
+  field :subject, 2, type: :string
+  field :reply, 3, type: :string
+  field :data, 4, type: :bytes
+  field :timestamp, 5, type: :int64
+  field :redelivered, 6, type: :bool
+  field :CRC32, 10, type: :uint32
+end
+
+defmodule Gnat.StreamingProtocol.Ack do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          subject: String.t(),
+          sequence: non_neg_integer
+        }
+  defstruct [:subject, :sequence]
+
+  field :subject, 1, type: :string
+  field :sequence, 2, type: :uint64
+end
+
+defmodule Gnat.StreamingProtocol.ConnectRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          clientID: String.t(),
+          heartbeatInbox: String.t(),
+          protocol: integer,
+          connID: binary,
+          pingInterval: integer,
+          pingMaxOut: integer
+        }
+  defstruct [:clientID, :heartbeatInbox, :protocol, :connID, :pingInterval, :pingMaxOut]
+
+  field :clientID, 1, type: :string
+  field :heartbeatInbox, 2, type: :string
+  field :protocol, 3, type: :int32
+  field :connID, 4, type: :bytes
+  field :pingInterval, 5, type: :int32
+  field :pingMaxOut, 6, type: :int32
+end
+
+defmodule Gnat.StreamingProtocol.ConnectResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          pubPrefix: String.t(),
+          subRequests: String.t(),
+          unsubRequests: String.t(),
+          closeRequests: String.t(),
+          error: String.t(),
+          subCloseRequests: String.t(),
+          pingRequests: String.t(),
+          pingInterval: integer,
+          pingMaxOut: integer,
+          protocol: integer,
+          publicKey: String.t()
+        }
+  defstruct [
+    :pubPrefix,
+    :subRequests,
+    :unsubRequests,
+    :closeRequests,
+    :error,
+    :subCloseRequests,
+    :pingRequests,
+    :pingInterval,
+    :pingMaxOut,
+    :protocol,
+    :publicKey
+  ]
+
+  field :pubPrefix, 1, type: :string
+  field :subRequests, 2, type: :string
+  field :unsubRequests, 3, type: :string
+  field :closeRequests, 4, type: :string
+  field :error, 5, type: :string
+  field :subCloseRequests, 6, type: :string
+  field :pingRequests, 7, type: :string
+  field :pingInterval, 8, type: :int32
+  field :pingMaxOut, 9, type: :int32
+  field :protocol, 10, type: :int32
+  field :publicKey, 100, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.Ping do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          connID: binary
+        }
+  defstruct [:connID]
+
+  field :connID, 1, type: :bytes
+end
+
+defmodule Gnat.StreamingProtocol.PingResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          error: String.t()
+        }
+  defstruct [:error]
+
+  field :error, 1, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.SubscriptionRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          clientID: String.t(),
+          subject: String.t(),
+          qGroup: String.t(),
+          inbox: String.t(),
+          maxInFlight: integer,
+          ackWaitInSecs: integer,
+          durableName: String.t(),
+          startPosition: atom | integer,
+          startSequence: non_neg_integer,
+          startTimeDelta: integer
+        }
+  defstruct [
+    :clientID,
+    :subject,
+    :qGroup,
+    :inbox,
+    :maxInFlight,
+    :ackWaitInSecs,
+    :durableName,
+    :startPosition,
+    :startSequence,
+    :startTimeDelta
+  ]
+
+  field :clientID, 1, type: :string
+  field :subject, 2, type: :string
+  field :qGroup, 3, type: :string
+  field :inbox, 4, type: :string
+  field :maxInFlight, 5, type: :int32
+  field :ackWaitInSecs, 6, type: :int32
+  field :durableName, 7, type: :string
+  field :startPosition, 10, type: Gnat.StreamingProtocol.StartPosition, enum: true
+  field :startSequence, 11, type: :uint64
+  field :startTimeDelta, 12, type: :int64
+end
+
+defmodule Gnat.StreamingProtocol.SubscriptionResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          ackInbox: String.t(),
+          error: String.t()
+        }
+  defstruct [:ackInbox, :error]
+
+  field :ackInbox, 2, type: :string
+  field :error, 3, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.UnsubscribeRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          clientID: String.t(),
+          subject: String.t(),
+          inbox: String.t(),
+          durableName: String.t()
+        }
+  defstruct [:clientID, :subject, :inbox, :durableName]
+
+  field :clientID, 1, type: :string
+  field :subject, 2, type: :string
+  field :inbox, 3, type: :string
+  field :durableName, 4, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.CloseRequest do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          clientID: String.t()
+        }
+  defstruct [:clientID]
+
+  field :clientID, 1, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.CloseResponse do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          error: String.t()
+        }
+  defstruct [:error]
+
+  field :error, 1, type: :string
+end
+
+defmodule Gnat.StreamingProtocol.StartPosition do
+  @moduledoc false
+  use Protobuf, enum: true, syntax: :proto3
+
+  field :NewOnly, 0
+  field :LastReceived, 1
+  field :TimeDeltaStart, 2
+  field :SequenceStart, 3
+  field :First, 4
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule Gnat.Mixfile do
       {:jason, "~> 1.1"},
       {:nimble_parsec, "~> 0.5"},
       {:propcheck, "~> 1.0", only: :test},
+      {:protobuf, "~> 0.6"},
       {:telemetry, "~> 0.4"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.1.4", "95852a3f050cc3ee1ef5c9ade14a3bd34e29b54cb8db7ae8bc7f716d904d5120", [:mix], [{:proper, "~> 1.3", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
+  "protobuf": {:hex, :protobuf, "0.6.1", "3ae3ca63d12d1a8c5b10c2e5fbc5145dccbff842ccd541109b74b20b631cea3b", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/gnat/streaming/client_test.exs
+++ b/test/gnat/streaming/client_test.exs
@@ -1,0 +1,99 @@
+defmodule Gnat.Streaming.ClientTest do
+  use ExUnit.Case, async: true
+  alias Gnat.Streaming.Client
+
+  @connect_response Gnat.Streaming.Protocol.ConnectResponse.new(
+    closeRequests: "test-cluster.abc123.close",
+    pubPrefix: "test-cluster.abc123.pub",
+    subRequests: "test-cluster.abc123.sub",
+    unsubRequests: "test-cluster.abc123.unsub"
+  )
+
+  describe "disconnected state" do
+    test "it starts in a disconnected state and tries to get connected" do
+      assert {:ok, :disconnected, state, actions} = Client.init(connection_name: :wat)
+      assert actions == [{:next_event, :internal, :connect}]
+      assert state.client_id != nil
+      assert state.conn_id != nil
+      assert state.connection_name == :wat
+      assert state.connection_pid == nil
+      assert state.heartbeat_subject != nil
+    end
+
+    test "failed connect attempts keep the state the same and retries connection" do
+      {:ok, :disconnected, state, _actions} = Client.init(connection_name: :wat)
+      assert {:keep_state_and_data, actions} = Client.disconnected(:internal, {:find_connection, nil}, state)
+      assert actions == [{:timeout, 250, :reconnect}]
+    end
+
+    test "finding the connection moves to connected status, tries to register client" do
+      {:ok, :disconnected, state, _actions} = Client.init(connection_name: :wat)
+      assert {:next_state, :connected, state, actions} = Client.disconnected(:internal, {:find_connection, self()}, state)
+      assert state.connection_pid == self()
+      assert actions == [{:next_event, :internal, :monitor_and_subscribe}]
+    end
+  end
+
+  describe "connected state" do
+    setup do
+      {:ok, :disconnected, state, _actions} = Client.init(connection_name: :wat)
+      {:next_state, :connected, state, _actions} = Client.disconnected(:internal, {:find_connection, self()}, state)
+      {:ok, %{state: state}}
+    end
+
+    test "succesful connect_response messages move to registered state", %{state: state} do
+      assert {:next_state, :registered, state, actions} = Client.connected(:internal, {:connect_response, @connect_response}, state)
+      assert state.close_subject == @connect_response.closeRequests
+      assert state.pub_subject == "#{@connect_response.pubPrefix}.#{state.client_id}.#{state.conn_id}"
+      assert state.sub_subject == @connect_response.subRequests
+      assert state.unsub_subject == @connect_response.unsubRequests
+      assert actions == []
+    end
+
+    @tag capture_log: true
+    test "failed connect_response does a delayed re-register", %{state: state} do
+      response = Map.put(@connect_response, :error, "500 unknown error")
+      assert {:keep_state_and_data, actions} = Client.connected(:internal, {:connect_response, response}, state)
+      assert actions == [{:timeout, 1_000, :reregister}]
+    end
+
+    test "connection dying pushes back to disconnected status", %{state: state} do
+      down_message = {:DOWN, make_ref(), :process, state.connection_pid, :malnurished}
+      assert {:next_state, :disconnected, state, actions} = Client.connected(:info, down_message, state)
+      assert state.connection_pid == nil
+      assert actions = [{:timeout, 250, :reconnect}]
+    end
+  end
+
+  describe "registered state" do
+    setup do
+      {:ok, :disconnected, state, _actions} = Client.init(connection_name: :wat)
+      {:next_state, :connected, state, _actions} = Client.disconnected(:internal, {:find_connection, self()}, state)
+      {:next_state, :registered, state, _actions} = Client.connected(:internal, {:connect_response, @connect_response}, state)
+      {:ok, %{state: state}}
+    end
+
+    test "receiving heartbeats", %{state: state} do
+      process_message = {:msg, %{body: "", reply_to: "send_a_heartbeat_here"}}
+      assert {:keep_state_and_data, actions} = Client.registered(:info, process_message, state)
+      assert actions == [{:next_event, :internal, {:pub, "send_a_heartbeat_here", ""}}]
+    end
+
+    test "calls for publishing info", %{state: state} do
+      assert {:keep_state_and_data, actions} = Client.registered({:call, :from}, :pub_info, state)
+      assert [{:reply, :from, {:ok, pub_info}}] = actions
+      assert pub_info == {state.client_id, state.pub_subject, state.connection_pid}
+    end
+
+    test "connection dying pushes back to disconnected status", %{state: state} do
+      down_message = {:DOWN, make_ref(), :process, state.connection_pid, :malnurished}
+      assert {:next_state, :disconnected, state, actions} = Client.registered(:info, down_message, state)
+      assert state.connection_pid == nil
+      assert state.close_subject == nil
+      assert state.pub_subject == nil
+      assert state.sub_subject == nil
+      assert state.unsub_subject == nil
+      assert actions = [{:timeout, 250, :reconnect}]
+    end
+  end
+end

--- a/test/gnat/streaming/subscription_test.exs
+++ b/test/gnat/streaming/subscription_test.exs
@@ -1,0 +1,85 @@
+defmodule Gnat.Streaming.SubscriptionTest do
+  use ExUnit.Case, async: true
+  alias Gnat.Streaming.Subscription
+
+  @subscription_response Gnat.Streaming.Protocol.SubscriptionResponse.new(
+    ackInbox: "pawnee.swansonLane"
+  )
+
+  describe "disconnected state" do
+    test "it starts in a disconnected state and tries to get connected" do
+      assert {:ok, :disconnected, state, actions} = Subscription.init(client_name: :wat, subject: "eagleton.parks")
+      assert actions == [{:next_event, :internal, :connect}]
+      assert state.client_id == nil
+      assert state.connection_pid == nil
+      assert state.client_name == :wat
+      assert state.subject == "eagleton.parks"
+    end
+
+    test "failed connect attempts keep the state the same and retries connection" do
+      {:ok, :disconnected, state, _actions} = Subscription.init(client_name: :wat, subject: "eagleton.parks")
+      assert {:keep_state_and_data, actions} = Subscription.disconnected(:internal, {:client_info, {:error, :disconnected}}, state)
+      assert actions == [{{:timeout, :reconnect}, 250, :reconnect}]
+    end
+
+    test "finding the connection moves to connected status, tries to register client" do
+      {:ok, :disconnected, state, _actions} = Subscription.init(client_name: :wat, subject: "eagleton.parks")
+      assert {:next_state, :connected, state, actions} = Subscription.disconnected(:internal, {:client_info, {:ok, {"client_id", "sub_subject", self()}}}, state)
+      assert state.client_id == "client_id"
+      assert state.connection_pid == self()
+      assert state.inbox == "client_id.eagleton.parks.INBOX"
+      assert state.sub_subject == "sub_subject"
+      assert actions == [{:next_event, :internal, :monitor_and_listen}]
+    end
+  end
+
+  describe "connected state" do
+    setup do
+      {:ok, :disconnected, state, _actions} = Subscription.init(client_name: :wat, subject: "eagleton.parks")
+      {:next_state, :connected, state, _actions} = Subscription.disconnected(:internal, {:client_info, {:ok, {"client_id", "sub_subject", self()}}}, state)
+      {:ok, %{state: state}}
+    end
+
+    test "succesful subscription_response moves to subscribed state", %{state: state} do
+      assert {:next_state, :subscribed, state, actions} = Subscription.connected(:internal, {:subscription_response, @subscription_response}, state)
+      assert state.ack_subject == @subscription_response.ackInbox
+      assert actions == []
+    end
+
+    @tag capture_log: true
+    test "failed subscription_response does a delayed re-register", %{state: state} do
+      response = Map.put(@subscription_response, :error, "500 unknown error")
+      assert {:keep_state_and_data, actions} = Subscription.connected(:internal, {:subscription_response, response}, state)
+      assert actions == [{{:timeout, :resubscribe}, 1_000, :resubscribe}]
+    end
+
+    test "connection dying pushes back to disconnected status", %{state: state} do
+      down_message = {:DOWN, make_ref(), :process, state.connection_pid, :malnurished}
+      assert {:next_state, :disconnected, state, actions} = Subscription.connected(:info, down_message, state)
+      assert state.client_id == nil
+      assert state.connection_pid == nil
+      assert state.inbox == nil
+      assert state.sub_subject == nil
+      assert actions = [{{:timeout, :reconnect}, 250, :reconnect}]
+    end
+  end
+
+  describe "subscribed state" do
+    setup do
+      {:ok, :disconnected, state, _actions} = Subscription.init(client_name: :wat, subject: "eagleton.parks")
+      {:next_state, :connected, state, _actions} = Subscription.disconnected(:internal, {:client_info, {:ok, {"client_id", "sub_subject", self()}}}, state)
+      {:next_state, :subscribed, state, _actions} = Subscription.connected(:internal, {:subscription_response, @subscription_response}, state)
+      {:ok, %{state: state}}
+    end
+
+    test "connection dying pushes back to disconnected status", %{state: state} do
+      down_message = {:DOWN, make_ref(), :process, state.connection_pid, :malnurished}
+      assert {:next_state, :disconnected, state, actions} = Subscription.subscribed(:info, down_message, state)
+      assert state.ack_subject == nil
+      assert state.client_id == nil
+      assert state.connection_pid == nil
+      assert state.inbox == nil
+      assert actions = [{{:timeout, :reconnect}, 250, :reconnect}]
+    end
+  end
+end

--- a/test/gnat/streaming/subscription_test.exs
+++ b/test/gnat/streaming/subscription_test.exs
@@ -82,8 +82,11 @@ defmodule Gnat.Streaming.SubscriptionTest do
       assert actions = [{{:timeout, :reconnect}, 250, :reconnect}]
     end
 
-    test "receiving messages from streaming server" do
-      # {:msg, %{body: pr_encoded_message, gnat: #PID<0.207.0>, reply_to: nil, sid: 2, topic: "3AFF97418E2AABEAAF7EE830.ohai.INBOX"}}
+    test "task_supervisor_pid dying stays in the same state, but replaces the TaskSupervisor", %{state: state} do
+      down_message = {:DOWN, make_ref(), :process, state.task_supervisor_pid, :DEAD}
+      assert {:keep_state, new_state} = Subscription.subscribed(:info, down_message, state)
+      assert new_state.task_supervisor_pid != state.task_supervisor_pid
+      assert Process.alive?(new_state.task_supervisor_pid)
     end
   end
 end

--- a/test/streaming_functional_test.exs
+++ b/test/streaming_functional_test.exs
@@ -1,0 +1,31 @@
+defmodule StreamingFunctionalTest do
+  use ExUnit.Case, async: true
+
+  def consume(msg) do
+    send :streaming_functional_test, {:message_received, msg}
+  end
+
+  def wait_for_subscription_to_be_subscribed(_pid) do
+    :timer.sleep(1_000)
+  end
+
+  @tag capture_log: true
+  test "it can subscribe and publish to NATS streaming" do
+    Process.register(self(), :streaming_functional_test)
+    {:ok, gnat} = Gnat.start_link(%{}, name: :streaming_connection)
+    {:ok, _client} = Gnat.Streaming.Client.start_link([connection_name: :streaming_connection], [name: :streaming_client])
+    {:ok, subscription} = Gnat.Streaming.Subscription.start_link(client_name: :streaming_client, subject: "ohai", consuming_function: {StreamingFunctionalTest, :consume})
+    wait_for_subscription_to_be_subscribed(subscription)
+
+    Gnat.Streaming.Client.pub(:streaming_client, "ohai", "What's up?")
+    assert_receive {:message_received, msg}
+    assert msg.connection_pid == gnat
+    assert msg.data == "What's up?"
+    assert msg.redelivered == false
+    assert msg.reply == ""
+    assert msg.sequence >= 0
+    assert msg.subject == "ohai"
+    assert msg.timestamp >= 0
+    assert Gnat.Streaming.Message.ack(msg) == :ok
+  end
+end


### PR DESCRIPTION
This is a ~~first~~ ~~second~~ third pass at streaming support. It follows a pattern of using `get_statem` process that finds a gnat connection, tries to register itself and then monitors the connection so that it can reset the state machine if the connection dies.

For example, here is a state diagram for a subscription

![Screen Shot 2019-05-10 at 8 22 29 AM](https://user-images.githubusercontent.com/80008/57534229-cbead280-72fc-11e9-8579-40ea5eae4fea.png)

In future PRs I'm imagining a higher-level supervisor that will automatically setup the connection, streaming client and subscribers by adding a single supervisor to a user's app.