### PR TITLE
Official supervisor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ end
 {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, token: "secret", auth_required: true})
 ```
 
+## TLS Connections
+
+[Nats Server](https://github.com/nats-io/nats-server) is often configured to accept or require TLS connections.
+In order to connect to these clusters you'll want to pass some extra TLS settings to your `Gnat` connection.
+
+```elixir
+# using a basic TLS connection
+{:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, tls: true})
+
+# Passing a Client Certificate for verification
+{:ok, gnat} = Gnat.start_link(%{tls: true, ssl_opts: [certfile: "client-cert.pem", keyfile: "client-key.pem"]})
+```
+
+## Resiliency
+
+If you would like to stay connected to a cluster of nats servers, you should consider using `Gnat.ConnectionSupervisor`.
+This can be added to your supervision tree in your project and will handle automatically re-connecting to the cluster.
+
+For long-lived subscriptions consider using `Gnat.ConsumerSupervisor`.
+This can also be added to your supervision tree and use a supervised connection to re-establish a subscription.
+It also handles details like handling each message in a supervised process so you isolate failures and get OTP logs when an unexpected error occurs.
+
 ## Instrumentation
 
 Gnat uses [telemetry](https://hex.pm/packages/telemetry) to make instrumentation data available to clients.

--- a/lib/gnat/connection_supervisor.ex
+++ b/lib/gnat/connection_supervisor.ex
@@ -3,9 +3,7 @@ defmodule Gnat.ConnectionSupervisor do
   require Logger
 
   @moduledoc """
-  A process that can supervise a named connection for you (EXPERIMENTAL)
-
-  > Note: This module is experimental and may be removed in the 1.0 release depending on what we find as we experiment with other forms of highly available connections.
+  A process that can supervise a named connection for you
 
   If you would like to supervise a Gnat connection and have it automatically re-connect in case of failure you can use this module in your supervision tree.
   It takes a map with the following data:

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -3,9 +3,7 @@ defmodule Gnat.ConsumerSupervisor do
   require Logger
 
   @moduledoc """
-  A process that can supervise consumers for you (EXPERIMENTAL)
-
-  > Note: This module is experimental and may be removed in the 1.0 release depending on what we find as we experiment with other forms of highly available connections.
+  A process that can supervise consumers for you
 
   If you want to subscribe to a few topics and have that subscription last across restarts for you, then this worker can be of help. It also spawns a supervised `Task` for each message it receives. This way errors in message processing don't crash the consumers, but you will still get SASL reports that you can send to services like honeybadger.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Gnat.Mixfile do
   def project do
     [
       app: :gnat,
-      version: "0.7.0",
-      elixir: "~> 1.6",
+      version: "1.0.0",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This addresses #94 

It documents the `ConnectionSupervisor` and `ConsumerSupervisor` as officially supported (they've been in production for multiple years now) and also bumps the library version to 1.0.0 since it's been stable for a while now.

Thanks @darrenclark for poking the project a little on this 🎉 🎈 💚 💙 