### PR TITLE
fix Gnat.ConsumerSupervisor crash when no queue group is specified

### DIFF
--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -60,8 +60,10 @@ defmodule Gnat.ConsumerSupervisor do
         _ref = Process.monitor(connection_pid)
         subscriptions = Enum.map(state.subscription_topics, fn(topic_and_queue_group) ->
           topic = Map.fetch!(topic_and_queue_group, :topic)
-          queue_group = Map.get(topic_and_queue_group, :queue_group)
-          {:ok, subscription} = Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
+          {:ok, subscription} = case Map.get(topic_and_queue_group, :queue_group) do
+            nil -> Gnat.sub(connection_pid, self(), topic)
+            queue_group -> Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
+          end
           subscription
         end)
         {:noreply, %{state | status: :connected, connection_pid: connection_pid, subscriptions: subscriptions}}


### PR DESCRIPTION
In the case that a `Gnat.ConsumerSupervisor` is configured without an explicit queue group, a `nil` queue group gets passed to `Command.build(:sub, topic, sid, opts)` on line 246 in `gnat.ex`.

```
    children = [
      %{
        id: :gnat_conn,
        start: {
          Gnat.ConnectionSupervisor,
          :start_link,
          [config_nats_conn()]
        },
        type: :supervisor
      },
      %{
        id: :gnat_sub,
        start: {
          Gnat.ConsumerSupervisor,
          :start_link,
          [config_nats_sub()]
        },
        type: :supervisor
      },
    ]

    opts = [
      strategy: :one_for_one
    ]
    Supervisor.start_link(children, opts)
```

```
  defp config_nats_conn do
    # Load configuration variables from the environment for connecting to NATS.
    nats_host = System.get_env("NATS_HOST", "localhost")
    {nats_port, _} = Integer.parse(System.get_env("NATS_PORT", "4222"))

    %{
      name: :gnat,
      backoff_period: 5_000,
      connection_settings: [
        %{host: nats_host, port: nats_port}
      ]
    }
  end

  defp config_nats_sub do
    # Given a NATS_CHANNEL environment variable, subscribe to that subject and
    # send the messages to the Producer pid.
    nats_channel = System.get_env("NATS_CHANNEL", "test")

    %{
      connection_name: :gnat,
      consuming_function: {Application, :nats_dbg},
      subscription_topics: [
        %{topic: nats_channel}
      ]
    }
  end
```

This commit adds a case to not pass on a `nil` queue group and allows
the `Command.build` to populate the queue group with the sid in the
empty case.