### PR TITLE
change log from info to debug when connecting to NATS

### DIFF
--- a/lib/gnat/connection_supervisor.ex
+++ b/lib/gnat/connection_supervisor.ex
@@ -57,7 +57,7 @@ defmodule Gnat.ConnectionSupervisor do
   @impl GenServer
   def handle_info(:attempt_connection, state) do
     connection_config = random_connection_config(state)
-    Logger.info "connecting to #{inspect connection_config}"
+    Logger.debug "connecting to #{inspect connection_config}"
     case Gnat.start_link(connection_config, name: state.name) do
       {:ok, gnat} -> {:noreply, %{state | gnat: gnat}}
       {:error, err} ->


### PR DESCRIPTION
Currently the ConnectionSupervisor will print out all inputs as part of Logger info. This can lead to unintended leaking of credentials into std.out

Closes #104