### PR TITLE
Request multi

### DIFF
--- a/bench/request_multi.exs
+++ b/bench/request_multi.exs
@@ -1,0 +1,39 @@
+defmodule EchoServer do
+  def run(gnat) do
+    spawn(fn -> init(gnat) end)
+  end
+
+  def init(gnat) do
+    Gnat.sub(gnat, self(), "echo")
+    loop(gnat)
+  end
+
+  def loop(gnat) do
+    receive do
+      {:msg, %{topic: "echo", reply_to: reply_to, body: msg}} ->
+        Gnat.pub(gnat, reply_to, msg)
+      other ->
+        IO.puts "server received: #{inspect other}"
+    end
+
+    loop(gnat)
+  end
+end
+
+{:ok, server_pid} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+# run 3 servers to get 3 responses
+EchoServer.run(server_pid)
+EchoServer.run(server_pid)
+EchoServer.run(server_pid)
+
+inputs = %{
+  "16 byte" => :crypto.strong_rand_bytes(16),
+  "128 byte" => :crypto.strong_rand_bytes(128),
+  "1024 byte" => :crypto.strong_rand_bytes(1024),
+}
+
+{:ok, client_pid} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+
+Benchee.run(%{
+  "request_multi" => fn(msg) -> {:ok, [%{body: _}, %{}, %{}]} = Gnat.request_multi(client_pid, "echo", msg, max_messages: 3) end,
+}, time: 10, parallel: 1, inputs: inputs, formatters: [{Benchee.Formatters.Console, comparisons: false}])

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -173,6 +173,23 @@ defmodule Gnat do
     response
   end
 
+  @doc """
+  Send a request and listen for multiple responses synchronously
+
+  This function makes it easy to do a scatter-gather operation where you wait for a limited time
+  and optionally a maximum number of replies.
+
+  Supported options:
+    * receive_timeout: an integer number of milliseconds to wait for responses. Defaults to 60_000
+    * max_messages: an integer number of messages to listen for. Defaults to -1 meaning unlimited
+    * headers: a set of headers you want to send with the request (see `Gnat.pub/4`)
+
+  ```
+  {:ok, gnat} = Gnat.start_link()
+  {:ok, responses} = Gnat.request_multi(gnat, "i_can_haz_fries", "plZZZZZ!?!?", max_messages: 5)
+  Enum.count(responses) #=> 5
+  ```
+  """
   @spec request_multi(t(), String.t(), binary(), keyword()) :: {:ok, list(message())}
   def request_multi(pid, topic, body, opts \\ []) do
     start = :erlang.monotonic_time()


### PR DESCRIPTION
This addresses https://github.com/nats-io/nats.ex/issues/117

@autodidaddict can you take a look and see if this looks useful for your situation? I ended up adding in both `receive_timeout` and `max_messages`. Some quick benchmarking shows that doing a `request_multi(gnat, topic, message, max_messages: 1)` has the same level of performance as the normal `request/4` function (~16k request/second single threaded on my laptop).