### PR TITLE
Server info in connection state

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -34,13 +34,13 @@ defmodule Gnat do
   * `inbox_prefix` - Prefix to use for the message inbox of this connection
   """
   @type connection_settings :: %{
-    connection_timeout: non_neg_integer(),
-    host: binary(),
-    inbox_prefix: binary(),
-    port: non_neg_integer(),
-    ssl_opts: list(),
-    tcp_opts: list(),
-    tls: boolean()
+    optional(:connection_timeout) => non_neg_integer(),
+    optional(:host) => binary(),
+    optional(:inbox_prefix) => binary(),
+    optional(:port) => non_neg_integer(),
+    optional(:ssl_opts) => list(),
+    optional(:tcp_opts) => list(),
+    optional(:tls) => boolean()
   }
 
   @typedoc """
@@ -95,11 +95,6 @@ defmodule Gnat do
     optional(:auth_required) => boolean(),
   }
 
-  @type connection :: %{
-    connection_settings: connection_settings(),
-    server_info: server_info()
-  }
-
   @default_connection_settings %{
     host: 'localhost',
     port: 4222,
@@ -130,7 +125,7 @@ defmodule Gnat do
 
   The final `opts` argument will be passed to the `GenServer.start_link` call so you can pass things like `[name: :gnat_connection]`.
   """
-  @spec start_link(map(), keyword()) :: GenServer.on_start
+  @spec start_link(connection_settings(), keyword()) :: GenServer.on_start
   def start_link(connection_settings \\ %{}, opts \\ []) do
     GenServer.start_link(__MODULE__, connection_settings, opts)
   end

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -24,6 +24,61 @@ defmodule Gnat do
   }
   @type sent_message :: {:msg, message()}
 
+  @typedoc """
+  * `connection_timeout` - limits how long it can take to establish a connection to a server
+  * `host` - The location of the NATS server
+  * `port` - The port the NATS server is listening on
+  * `ssl_opts` - Options for connecting over SSL
+  * `tcp_opts` - Options for connecting over TCP
+  * `tls` - If the server should use a TLS connection
+  * `inbox_prefix` - Prefix to use for the message inbox of this connection
+  """
+  @type connection_settings :: %{
+    connection_timeout: non_neg_integer(),
+    host: binary(),
+    inbox_prefix: binary(),
+    port: non_neg_integer(),
+    ssl_opts: list(),
+    tcp_opts: list(),
+    tls: boolean()
+  }
+
+  @typedoc """
+  * `client_id` - An optional unsigned integer (64 bits) representing the internal client identifier in the server. This can be used to filter client connections in monitoring, correlate with error logs, etc...
+  * `client_ip` - The IP address the client is connecting from
+  * `git_commit` - The git commit associated with this NATS version
+  * `go` - The version of golang the NATS server was built with
+  * `headers` - If messages can have headers in them
+  * `host` - The IP address used to start the NATS server, by default this will be 0.0.0.0 and can be configured with -client_advertise host:port
+  * `jetstream` - If the server is using JetStream features
+  * `max_payload` - Maximum payload size, in bytes, that the server will accept from the client
+  * `port` - The port number the NATS server is configured to listen on
+  * `proto` - An integer indicating the protocol version of the server. The server version 1.2.0 sets this to 1 to indicate that it supports the "Echo" feature.
+  * `server_id` - The unique identifier of the NATS server
+  * `server_name` - A name for the server
+  * `version` - The version of the NATS server
+  """
+  @type server_info :: %{
+    client_id: non_neg_integer(),
+    client_ip: binary(),
+    git_commit: binary(),
+    go: binary(),
+    headers: boolean(),
+    host: binary(),
+    jetstream: binary(),
+    max_payload: integer(),
+    port: non_neg_integer(),
+    proto: integer(),
+    server_id: binary(),
+    server_name: binary(),
+    version: binary(),
+  }
+
+  @type connection :: %{
+    connection_settings: connection_settings(),
+    server_info: server_info()
+  }
+
   @default_connection_settings %{
     host: 'localhost',
     port: 4222,

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -44,8 +44,14 @@ defmodule Gnat do
   }
 
   @typedoc """
+  [Info Protocol](https://docs.nats.io/reference/reference-protocols/nats-protocol#info)
+
   * `client_id` - An optional unsigned integer (64 bits) representing the internal client identifier in the server. This can be used to filter client connections in monitoring, correlate with error logs, etc...
   * `client_ip` - The IP address the client is connecting from
+  * `cluster` - The name of the cluster if any
+  * `cluster_dynamic` - If the cluster is dynamic
+  * `connect_urls` - An optional list of server urls that a client can connect to.
+  * `ws_connect_urls` - An optional list of server urls that a websocket client can connect to.
   * `git_commit` - The git commit associated with this NATS version
   * `go` - The version of golang the NATS server was built with
   * `headers` - If messages can have headers in them
@@ -57,21 +63,36 @@ defmodule Gnat do
   * `server_id` - The unique identifier of the NATS server
   * `server_name` - A name for the server
   * `version` - The version of the NATS server
+  * `ldm` - If the server supports Lame Duck Mode notifications, and the current server has transitioned to lame duck, ldm will be set to true.
+  * `auth_required` - If this is set, then the client should try to authenticate upon connect.
+  * `tls_required` - If this is set, then the client must perform the TLS/1.2 handshake. Note, this used to be ssl_required and has been updated along with the protocol from SSL to TLS.
+  * `tls_verify` - If this is set, the client must provide a valid certificate during the TLS handshake.
+  * `tls_available` - If the server can use TLS
   """
   @type server_info :: %{
-    client_id: non_neg_integer(),
-    client_ip: binary(),
-    git_commit: binary(),
-    go: binary(),
-    headers: boolean(),
-    host: binary(),
-    jetstream: binary(),
-    max_payload: integer(),
-    port: non_neg_integer(),
-    proto: integer(),
-    server_id: binary(),
-    server_name: binary(),
-    version: binary(),
+    :client_id => non_neg_integer(),
+    :client_ip => binary(),
+    optional(:ip) => binary(),
+    optional(:cluster) => binary(),
+    optional(:cluster_dynamic) => boolean(),
+    optional(:connect_urls) => list(binary()),
+    optional(:ws_connect_urls) => list(binary()),
+    optional(:git_commit) => binary(),
+    :go => binary(),
+    :headers => boolean(),
+    :host => binary(),
+    optional(:jetstream) => binary(),
+    :max_payload => integer(),
+    :port => non_neg_integer(),
+    :proto => integer(),
+    :server_id => binary(),
+    :server_name => binary(),
+    :version => binary(),
+    optional(:ldm) => boolean(),
+    optional(:tls_verify) => boolean(),
+    optional(:tls_available) => boolean(),
+    optional(:tls_required) => boolean(),
+    optional(:auth_required) => boolean(),
   }
 
   @type connection :: %{

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -27,7 +27,7 @@ defmodule Gnat.Handshake do
         {:ok, socket} = upgrade_connection(tcp, user_settings)
         settings = negotiate_settings(server_settings, user_settings)
         :ok = send_connect(user_settings, settings, socket)
-        {:ok, socket}
+        {:ok, socket, server_settings}
       after 1000 ->
         {:error, "timed out waiting for info"}
     end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -285,4 +285,11 @@ defmodule GnatTest do
     {:ok, msg} = Gnat.request(pid, topic, "ohai", receive_timeout: 500, headers: headers)
     assert "custom._INBOX." <> _ = msg.topic
   end
+
+  test "server_info/1 returns server info" do
+    {:ok, pid} = Gnat.start_link()
+    info = Gnat.server_info(pid)
+    assert Map.has_key?(info, :version)
+    assert is_binary(info.version)
+  end
 end


### PR DESCRIPTION
Addresses https://github.com/nats-io/nats.ex/issues/123

Includes information about the NATS server that can be accessed from a connection. 