### PR TITLE
parse hmsg with status code and description

### DIFF
--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -113,14 +113,20 @@ defmodule Gnat.Parsec do
     end
   end
 
-  def parse_headers("NATS/1.0\r\n" <> headers) do
-    case :cow_http.parse_headers(headers) do
-      {parsed, ""} -> {:ok, parsed}
-      _other -> {:error, "Could not parse headers"}
+  def parse_headers("NATS/1.0" <> rest) do
+    case String.split(rest, "\r\n", parts: 2) do
+      [_status_line, headers] ->
+        case :cow_http.parse_headers(headers) do
+          {parsed, ""} -> {:ok, parsed}
+          _other -> {:error, "Could not parse headers"}
+        end
+      _other ->
+        {:error, "Could not parse status line"}
     end
+
   end
   def parse_headers(_other) do
-    {:error, "Could not parse headers"}
+    {:error, "Could not parse status line prefix"}
   end
 
   def finish_msg(subject, sid, reply_to, length, rest, string) do


### PR DESCRIPTION
This fixes the bug from #122

I got the parsec working correctly here, but I think we should also return the status code and/or description back to the recipient. This PR currently throws that data away, but especially in the case of the pull request with no wait, it seems very useful to let the caller know that we got back a 404 vs a 503 or some other status code.