### PR TITLE
Add function to get a new inbox

### DIFF
--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -296,13 +296,14 @@ defmodule GnatTest do
   test "make_new_inbox/1 returns an inbox name" do
     {:ok, pid} = Gnat.start_link()
     inbox = Gnat.make_new_inbox(pid)
-    assert inbox =~ "_INBOX."
+    assert [inbox, _nuid] =  String.split(inbox, ".")
+    assert inbox == "_INBOX"
   end
 
   test "make_new_inbox/1 uses custom prefix" do
-    {:ok, pid} = Gnat.start_link(%{inbox_prefix: "FOO"})
+    {:ok, pid} = Gnat.start_link(%{inbox_prefix: "FOO."})
     inbox = Gnat.make_new_inbox(pid)
-    assert inbox =~ "FOO"
-    refute inbox =~ "_INBOX."
+    assert [inbox, _nuid] =  String.split(inbox, ".")
+    assert inbox == "FOO"
   end
 end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -292,4 +292,17 @@ defmodule GnatTest do
     assert Map.has_key?(info, :version)
     assert is_binary(info.version)
   end
+
+  test "make_new_inbox/1 returns an inbox name" do
+    {:ok, pid} = Gnat.start_link()
+    inbox = Gnat.make_new_inbox(pid)
+    assert inbox =~ "_INBOX."
+  end
+
+  test "make_new_inbox/1 uses custom prefix" do
+    {:ok, pid} = Gnat.start_link(%{inbox_prefix: "FOO"})
+    inbox = Gnat.make_new_inbox(pid)
+    assert inbox =~ "FOO"
+    refute inbox =~ "_INBOX."
+  end
 end


### PR DESCRIPTION
Primarily useful for libraries like Jetstream and Polyn, built on top of `gnat` that also need to setup a temporary inbox to receive messages.