### PR TITLE
Add a test and some documentation for IPv6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ workflows:
   testing_all_versions:
     jobs:
       - build:
-          name: "Test Elixir 1.13.1"
-          version: 1.13.1
+          name: "Test Elixir 1.13.4"
+          version: 1.13.4
       - build:
           name: "Test Elixir 1.12.3"
           version: 1.12.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           - "deps"
           - "_build"
           - "~/.mix"
-      - run: mix test --include multi_server
+      - run: mix test --include multi_server --exclude ci_skip
       - run: N=400 mix test --only property
   lint:
     parameters:

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -118,6 +118,8 @@ defmodule Gnat do
   {:ok, gnat} = Gnat.start_link(%{tls: true, ssl_opts: [certfile: "client-cert.pem", keyfile: "client-key.pem"]})
   # you can customize default "_INBOX." inbox prefix with:
   {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, inbox_prefix: "my_prefix._INBOX."})
+  # you can use IPv6 addresses too
+  {:ok, gnat} = Gnat.start_link(%{host: '::1', port: 4222, tcp_opts: [:inet6, :binary]})
   ```
 
   You can also pass arbitrary SSL or TCP options in the `tcp_opts` and `ssl_opts` keys.

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -13,6 +13,9 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
+  # We have to skip this test in CI builds because CircleCI doesn't enable IPv6 in it's docker
+  # configuration. See https://circleci.com/docs/faq#can-i-use-ipv6-in-my-tests
+  @tag :ci_skip
   test "connect to a server over IPv6" do
     {:ok, pid} = Gnat.start_link(%{host: '::1', tcp_opts: [:binary, :inet6]})
     assert Process.alive?(pid)

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -13,6 +13,12 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
+  test "connect to a server over IPv6" do
+    {:ok, pid} = Gnat.start_link(%{host: '::1', tcp_opts: [:binary, :inet6]})
+    assert Process.alive?(pid)
+    :ok = Gnat.stop(pid)
+  end
+
   @tag :multi_server
   test "connect to a server with user/pass authentication" do
     connection_settings = %{


### PR DESCRIPTION
Adresses #129 

We do support IPv6 already, but it wasn't very clear in the documentation. So this adds a function doc and a unit test.