### PR TITLE
No responders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-[![circleci.com](https://circleci.com/gh/nats-io/nats.ex/tree/master.svg?style=svg)](https://circleci.com/gh/nats-io/nats.ex/tree/master)
 [![hex.pm](https://img.shields.io/hexpm/v/gnat.svg)](https://hex.pm/packages/gnat)
 [![hex.pm](https://img.shields.io/hexpm/dt/gnat.svg)](https://hex.pm/packages/gnat)
 [![hex.pm](https://img.shields.io/hexpm/l/gnat.svg)](https://hex.pm/packages/gnat)
 [![github.com](https://img.shields.io/github/last-commit/nats-io/nats.ex.svg)](https://github.com/nats-io/nats.ex)
 
-![NATS](https://branding.cncf.io/img/projects/nats/stacked/color/nats-stacked-color.svg)
+![NATS](https://nats.io/img/logos/nats-horizontal-color.png)
 
 # Gnat
 

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -18,6 +18,7 @@ defmodule Gnat.Handshake do
     %{verbose: false}
     |> negotiate_auth(server_settings, user_settings)
     |> negotiate_headers(server_settings, user_settings)
+    |> negotiate_no_responders(server_settings, user_settings)
   end
 
   defp perform_handshake(tcp, user_settings) do
@@ -74,6 +75,13 @@ defmodule Gnat.Handshake do
     raise "NATS Server does not support headers, but your connection settings specify header support"
   end
   defp negotiate_headers(settings, _server, _user) do
+    settings
+  end
+
+  defp negotiate_no_responders(%{headers: true} = settings, _server_settings, %{no_responders: true}) do
+    Map.put(settings, :no_responders, true)
+  end
+  defp negotiate_no_responders(settings, _server_settings, _user_settings) do
     settings
   end
 

--- a/test/gnat/parsec_test.exs
+++ b/test/gnat/parsec_test.exs
@@ -39,7 +39,7 @@ defmodule Gnat.ParsecTest do
 
     {state, [parsed]} = Parsec.new() |> Parsec.parse(binary)
     assert state.partial == nil
-    assert parsed == {:hmsg, "SUBJECT", 1, nil, [{"header", "X"}], "PAYLOAD"}
+    assert parsed == {:hmsg, "SUBJECT", 1, nil, nil, nil, [{"header", "X"}], "PAYLOAD"}
   end
 
   test "parsing messages with headers - single header" do
@@ -47,7 +47,7 @@ defmodule Gnat.ParsecTest do
 
     {state, [parsed]} = Parsec.new() |> Parsec.parse(binary)
     assert state.partial == nil
-    assert parsed == {:hmsg, "SUBJECT", 1, "REPLY",[{"header", "X"}], "PAYLOAD"}
+    assert parsed == {:hmsg, "SUBJECT", 1, "REPLY", nil, nil, [{"header", "X"}], "PAYLOAD"}
   end
 
   # This example comes from https://github.com/nats-io/nats-architecture-and-design/blob/cb8f68af6ba730c00a6aa174dedaa217edd9edc6/adr/ADR-9.md
@@ -56,7 +56,7 @@ defmodule Gnat.ParsecTest do
 
     {state, [parsed]} = Parsec.new() |> Parsec.parse(binary)
     assert state.partial == nil
-    assert parsed == {:hmsg, "my.messages", 2, nil,[{"nats-last-consumer", "0"}, {"nats-last-stream", "0"}], ""}
+    assert parsed == {:hmsg, "my.messages", 2, nil, "100", "Idle Heartbeat", [{"nats-last-consumer", "0"}, {"nats-last-stream", "0"}], ""}
   end
 
   # This example comes from https://github.com/nats-io/nats-architecture-and-design/blob/682d5cd5f21d18502da70025727128a407655250/adr/ADR-13.md
@@ -65,7 +65,15 @@ defmodule Gnat.ParsecTest do
 
     {state, [parsed]} = Parsec.new() |> Parsec.parse(binary)
     assert state.partial == nil
-    assert parsed == {:hmsg, "_INBOX.x7tkDPDLCOEknrfB4RH1V7.OgY4M7", 2, nil, [], ""}
+    assert parsed == {:hmsg, "_INBOX.x7tkDPDLCOEknrfB4RH1V7.OgY4M7", 2, nil, "404", "No Messages", [], ""}
+  end
+
+  test "parsing no_responders messages" do
+    binary = "HMSG _INBOX.10ahfXw89Nx5htVf.7Il73yuah/RHW6w8 0 16 16\r\nNATS/1.0 503\r\n\r\n\r\n"
+
+    {state, [parsed]} = Parsec.new() |> Parsec.parse(binary)
+    assert state.partial == nil
+    assert parsed == {:hmsg, "_INBOX.10ahfXw89Nx5htVf.7Il73yuah/RHW6w8", 0, nil, "503", nil, [], ""}
   end
 
   test "parsing PING message" do

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -266,6 +266,12 @@ defmodule GnatTest do
     assert Enum.all?(messages, fn msg -> msg.body == "ohai" end)
   end
 
+  test "request_multi with no_responders" do
+    topic = "nobody.is.home"
+    {:ok, pid} = Gnat.start_link(%{no_responders: true})
+    assert {:error, :no_responders} = Gnat.request_multi(pid, topic, "ohai", max_messages: 2)
+  end
+
   defp spin_up_echo_server_on_topic(ready, gnat, topic) do
     spawn(fn ->
       {:ok, subscription} = Gnat.sub(gnat, self(), topic)

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -188,7 +188,7 @@ defmodule GnatTest do
     end
   end
 
-  test "request-reply convenience function with headers" do
+  test "request-reply convenience function" do
     topic = "req-resp"
     {:ok, pid} = Gnat.start_link()
     spin_up_echo_server_on_topic(self(), pid, topic)
@@ -198,7 +198,7 @@ defmodule GnatTest do
     assert msg.body == "ohai"
   end
 
-  test "request-reply convenience function" do
+  test "request-reply convenience function with headers" do
     topic = "req-resp"
     {:ok, pid} = Gnat.start_link()
     spin_up_echo_server_on_topic(self(), pid, topic)
@@ -208,6 +208,20 @@ defmodule GnatTest do
     {:ok, msg} = Gnat.request(pid, topic, "ohai", receive_timeout: 500, headers: headers)
     assert msg.body == "ohai"
     assert msg.headers == headers
+  end
+
+  @tag timeout: 100
+  test "request-reply no_responders" do
+    topic = "nobody-is-listening-to-this-topic"
+    {:ok, pid} = Gnat.start_link(%{no_responders: true})
+    assert {:error, :no_responders} = Gnat.request(pid, topic, "ohai")
+  end
+
+  @tag timeout: 100
+  test "request-reply timeout" do
+    topic = "nobody-is-listening-to-this-topic"
+    {:ok, pid} = Gnat.start_link()
+    assert {:error, :timeout} = Gnat.request(pid, topic, "ohai", receive_timeout: 5)
   end
 
   test "request_multi convenience function with no maximum messages" do


### PR DESCRIPTION
Resolves #136 

The NATS server has the ability to send reply messages with a status of `503` when a message is sent to a topic with no subscribers. This is really handy for request-reply semantics so you can get an immediate error response rather than waiting for the `receive_timeout` to expire. Because this behavior is backwards incompatible, it must be opted into by the client.

I've written this PR assuming that we also want our users to opt into this behavior rather than making it the default, but I'm open to feedback on this point. Maybe we should default the `no_responders: true` after the next major version release?

If headers are enabled, and the user has passed in `no_responders: true` with their connection options, then the server will send back HMSG payloads with an empty body and a "503" status. In order to watch for this case in the code I also added parsing of the `status` and `description` from headers. Previously these have been ignored because I didn't know of a use-case for passing them back to the user, but I think it does make sense to provide this back to the user.