### PR TITLE
include elixir 1.14.2 in the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-default_version: &default_version 1.13.1
+default_version: &default_version 1.14.2
 
 jobs:
   build:
@@ -86,6 +86,9 @@ workflows:
   version: 2.1
   testing_all_versions:
     jobs:
+      - build:
+          name: "Test Elixir 1.14.2"
+          version: 1.14.2
       - build:
           name: "Test Elixir 1.13.4"
           version: 1.13.4


### PR DESCRIPTION
The test suite for this library is tested on the latest elixir versions from 1.7 => 1.13. Time for us to add elixir 1.14 to the test matrix so we can confirm support for erlang 25 and elixir 1.14