### PR TITLE
Adding initial services API support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,23 +92,14 @@ workflows:
       - build:
           name: "Test Elixir 1.13.4"
           version: 1.13.4
-# - build:
-#     name: "Test Elixir 1.12.3"
-#     version: 1.12.3
-# - build:
-#     name: "Test Elixir 1.11.4"
-#     version: 1.11.4
-# - build:
-#     name: "Test Elixir 1.10.4"
-#     version: 1.10.4
-#   - build:
-#       name: "Test Elixir 1.9.4"
-#       version: 1.9.4
-#   - build:
-#       name: "Test Elixir 1.8.2"
-#       version: 1.8.2
-#   - build:
-#       name: "Test Elixir 1.7.4"
-#       version: 1.7.4
+      - build:
+          name: "Test Elixir 1.12.3"
+          version: 1.12.3
+      - build:
+          name: "Test Elixir 1.11.4"
+          version: 1.11.4
+      - build:
+          name: "Test Elixir 1.10.4"
+          version: 1.10.4
       - lint:
           name: "Check formatting and Types"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,14 +101,14 @@ workflows:
       - build:
           name: "Test Elixir 1.10.4"
           version: 1.10.4
-      - build:
-          name: "Test Elixir 1.9.4"
-          version: 1.9.4
-      - build:
-          name: "Test Elixir 1.8.2"
-          version: 1.8.2
-      - build:
-          name: "Test Elixir 1.7.4"
-          version: 1.7.4
+#   - build:
+#       name: "Test Elixir 1.9.4"
+#       version: 1.9.4
+#   - build:
+#       name: "Test Elixir 1.8.2"
+#       version: 1.8.2
+#   - build:
+#       name: "Test Elixir 1.7.4"
+#       version: 1.7.4
       - lint:
           name: "Check formatting and Types"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,15 +92,15 @@ workflows:
       - build:
           name: "Test Elixir 1.13.4"
           version: 1.13.4
-      - build:
-          name: "Test Elixir 1.12.3"
-          version: 1.12.3
-      - build:
-          name: "Test Elixir 1.11.4"
-          version: 1.11.4
-      - build:
-          name: "Test Elixir 1.10.4"
-          version: 1.10.4
+# - build:
+#     name: "Test Elixir 1.12.3"
+#     version: 1.12.3
+# - build:
+#     name: "Test Elixir 1.11.4"
+#     version: 1.11.4
+# - build:
+#     name: "Test Elixir 1.10.4"
+#     version: 1.10.4
 #   - build:
 #       name: "Test Elixir 1.9.4"
 #       version: 1.9.4

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,3 +5,4 @@ Maintainership is on a per project basis.
 ### Maintainers
   - Colin Sullivan <colin@nats.io> [@ColinSullivan1](https://github.com/ColinSullivan1)
   - Michael Ries <riesmmm@gmail.com> [@mmmries](https://github.com/mmmries)
+  - Kevin Hoffman <alothien@gmail.com> [@autodidaddict](https//github.com/autodidaddict)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ For long-lived subscriptions consider using `Gnat.ConsumerSupervisor` .
 This can also be added to your supervision tree and use a supervised connection to re-establish a subscription.
 It also handles details like handling each message in a supervised process so you isolate failures and get OTP logs when an unexpected error occurs.
 
-## Microservices
-If you supply a module that implements the `Gnat.Services.Server` behavior and the `microservice` 
+## Services
+If you supply a module that implements the `Gnat.Services.Server` behavior and the `service_definition` 
 configuration field to a `Gnat.ConsumerSupervisor`, then this client will automatically take care
 of exposing the service to discovery, responding to pings, and maintaining and exposing statistics like request and error counts, and processing times.
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ end
 # with token
 {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, token: "secret", auth_required: true})
 
-# with nkeys
+# with an nkey seed
 {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, nkey_seed: "SUAM...", auth_required: true})
 
-# with user credentials
+# with decentralized user credentials (JWT)
 {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, nkey_seed: "SUAM...", jwt: "eyJ0eX...", auth_required: true})
 
-# connect to NGS
+# connect to NGS with JWT
 {:ok, gnat} = Gnat.start_link(%{host: "connect.ngs.global", tls: true, jwt: "ey...", nkey_seed: "SUAM..."})
 ```
 
 ## TLS Connections
 
-[Nats Server](https://github.com/nats-io/nats-server) is often configured to accept or require TLS connections.
+[NATS Server](https://github.com/nats-io/nats-server) is often configured to accept or require TLS connections.
 In order to connect to these clusters you'll want to pass some extra TLS settings to your `Gnat` connection.
 
 ``` elixir
@@ -68,6 +68,11 @@ For long-lived subscriptions consider using `Gnat.ConsumerSupervisor` .
 This can also be added to your supervision tree and use a supervised connection to re-establish a subscription.
 It also handles details like handling each message in a supervised process so you isolate failures and get OTP logs when an unexpected error occurs.
 
+## Microservices
+If you supply a module that implements the `Gnat.Services.Server` behavior and the `microservice` 
+configuration field to a `Gnat.ConsumerSupervisor`, then this client will automatically take care
+of exposing the service to discovery, responding to pings, and maintaining and exposing statistics like request and error counts, and processing times.
+
 ## Instrumentation
 
 Gnat uses [telemetry](https://hex.pm/packages/telemetry) to make instrumentation data available to clients.
@@ -85,7 +90,9 @@ iex(2)> names = [[:gnat, :pub], [:gnat, :sub], [:gnat, :message_received], [:gna
   [:gnat, :sub],
   [:gnat, :message_received],
   [:gnat, :request],
-  [:gnat, :unsub]
+  [:gnat, :unsub],
+  [:gnat, :service_request],
+  [:gnat, :service_error]
 ]
 iex(3)> :telemetry.attach_many("my listener", names, metrics_function, %{my_config: true})
 :ok
@@ -101,7 +108,8 @@ iex(6)> Gnat.pub(gnat, "topic", "ohai")
 ```
 
 The `pub` , `sub` , `request` , and `unsub` events all report the latency of those respective calls.
-The `message_received` event reports a number of messages like `%{count: 1}` because there isn't a good latency metric to report.
+The `message_received` event reports a number of messages like `%{count: 1}` because there isn't a good latency metric to report. Any microservices managed by a consumer supervisor will also report `service_request` and `service_error`. In addition to the `:topic` metadata, microservices will also include `:endpoint` and `:group` (which can be `nil`) in their telemetry reports.
+
 All of the events (except `unsub` ) include metadata with a `:topic` key so you can split your metrics by topic.
 
 ## Benchmarks
@@ -122,7 +130,8 @@ As of this commit my 2018 MacBook pro shows.
 
 ## Development
 
-Before running the tests make sure you have a locally running copy of `nats-server` ( `brew install nats-server` ).
+Before running the tests make sure you have a locally running copy of `nats-server` ([installation instructions](https://docs.nats.io/running-a-nats-service/introduction/installation)).
+
 We currently use version `2.6.6` in CI, but anything higher than `2.2.0` should be fine.
 Versions from `0.9.6` up to `2.2.0` should work fine for everything except header support.
 The typical `mix test` will run all the basic unit tests.

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -379,9 +379,7 @@ defmodule Gnat do
   @impl GenServer
   def init(connection_settings) do
     connection_settings = Map.merge(@default_connection_settings, connection_settings)
-    if :ets.whereis(:endpoint_stats) == :undefined do
-      :ets.new(:endpoint_stats, [:public, :set, :named_table])
-    end
+
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket, server_info} ->
         parser = Parsec.new

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -3,6 +3,9 @@
 #  :waiting_for_message => receive MSG... -> :waiting_for_message
 
 defmodule Gnat do
+  @moduledoc """
+  The primary interface for interacting with NATS
+  """
   use GenServer
   require Logger
   alias Gnat.{Command, Parsec}
@@ -10,17 +13,26 @@ defmodule Gnat do
   @type t :: GenServer.server()
   @type headers :: [{binary(), iodata()}]
 
-  # A message received from NATS will be delivered to your process in this form.
-  # Please note that the `:reply_to` and `:headers` keys are optional.
-  # They will only be present if the message was received from the NATS server with
-  # headers or a reply_to topic
+  @typedoc """
+  A message received from NATS will be delivered to your process in this form.
+  Please note that the `:reply_to` and `:headers` keys are optional.
+  They will only be present if the message was received from the NATS server with
+  headers or a `reply_to` topic
+
+  * `gnat` - The Gnat connection
+  * `topic` - The topic on which the message arrived
+  * `body` - The raw payload of the message
+  * `sid` - The subscription ID corresponding to this message. You generally won't need to use this value directly.
+  * `reply_to` - A topic supplied for expected replies
+  * `headers` - A set of NATS message headers on the message
+  """
   @type message :: %{
-    gnat: t(),
-    topic: String.t(),
-    body: String.t(),
-    sid: non_neg_integer(),
-    reply_to: String.t(),
-    headers: headers()
+    required(:gnat) => t(),
+    required(:topic) => binary(),
+    required(:body) => iodata(),
+    required(:sid) => non_neg_integer(),
+    optional(:reply_to) => binary(),
+    optional(:headers) => headers()
   }
   @type sent_message :: {:msg, message()}
 
@@ -185,7 +197,7 @@ defmodule Gnat do
   ```
 
   If you want to provide a reply address to receive a response you can pass it as an option.
-  [See request-response pattern](http://nats.io/documentation/concepts/nats-req-rep/).
+  [See request-reply pattern](https://docs.nats.io/nats-concepts/core-nats/reqreply).
 
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -217,12 +229,12 @@ defmodule Gnat do
   @doc """
   Send a request and listen for a response synchronously
 
-  Following the nats [request-response pattern](http://nats.io/documentation/concepts/nats-req-rep/) this
+  Following the nats [request-reply pattern](https://docs.nats.io/nats-concepts/core-nats/reqreply) this
   function generates a one-time topic to receive replies and then sends a message to the provided topic.
 
   Supported options:
-    * receive_timeout: an integer number of milliseconds to wait for a response. Defaults to 60_000
-    * headers: a set of headers you want to send with the request (see `Gnat.pub/4`)
+    * `receive_timeout` - An integer number of milliseconds to wait for a response. Defaults to 60_000
+    * `headers` - A set of headers you want to send with the request (see `Gnat.pub/4`)
 
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -266,9 +278,9 @@ defmodule Gnat do
   and optionally a maximum number of replies.
 
   Supported options:
-    * receive_timeout: an integer number of milliseconds to wait for responses. Defaults to 60_000
-    * max_messages: an integer number of messages to listen for. Defaults to -1 meaning unlimited
-    * headers: a set of headers you want to send with the request (see `Gnat.pub/4`)
+    * `receive_timeout` - An integer number of milliseconds to wait for responses. Defaults to 60_000
+    * `max_messages` - An integer number of messages to listen for. Defaults to -1 meaning unlimited
+    * `headers` - A set of headers you want to send with the request (see `Gnat.pub/4`)
 
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -307,12 +319,12 @@ defmodule Gnat do
   Unsubscribe from a topic
 
   Supported options:
-    * max_messages: number of messages to be received before automatically unsubscribed
+    * `max_messages` - Number of messages to be received before automatically unsubscribed
 
-  This correlates to the [UNSUB](http://nats.io/documentation/internals/nats-protocol/#UNSUB) command in the nats protocol.
+  This correlates to the [UNSUB](https://docs.nats.io/reference/reference-protocols/nats-protocol#unsub) command in the nats protocol.
   By default the unsubscribe is affected immediately, but an optional `max_messages` value can be provided which will allow
   `max_messages` to be received before affecting the unsubscribe.
-  This is especially useful for [request response](http://nats.io/documentation/concepts/nats-req-rep/) patterns.
+  This is especially useful for request/reply patterns.
 
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -333,7 +345,7 @@ defmodule Gnat do
   @doc """
   Ping the NATS server
 
-  This correlates to the [PING](http://nats.io/documentation/internals/nats-protocol/#PINGPONG) command in the NATS protocol.
+  This correlates to the [PING](https://docs.nats.io/reference/reference-protocols/nats-protocol#ping-pong) command in the NATS protocol.
   If the NATS server responds with a PONG message this function will return `:ok`
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -350,7 +362,7 @@ defmodule Gnat do
     end
   end
 
-  @doc "get the number of active subscriptions"
+  @doc "Get the number of active subscriptions"
   @spec active_subscriptions(t()) :: {:ok, non_neg_integer()}
   def active_subscriptions(pid) do
     GenServer.call(pid, :active_subscriptions)
@@ -367,6 +379,9 @@ defmodule Gnat do
   @impl GenServer
   def init(connection_settings) do
     connection_settings = Map.merge(@default_connection_settings, connection_settings)
+    if :ets.whereis(:endpoint_stats) == :undefined do
+      :ets.new(:endpoint_stats, [:public, :set, :named_table])
+    end
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket, server_info} ->
         parser = Parsec.new

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -203,6 +203,9 @@ defmodule Gnat.ConsumerSupervisor do
   end
 
   defp initialize_as_microservice(state, connection_pid) do
+    if :ets.whereis(:endpoint_stats) == :undefined do
+      :ets.new(:endpoint_stats, [:public, :set, :named_table])
+    end
     {:ok, responder_pid} = ServiceResponder.start_link(%{ state | connection_pid: connection_pid })
     endpoints = get_in(state, [:service_config, :endpoints])
 

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -1,6 +1,10 @@
 defmodule Gnat.ConsumerSupervisor do
+  # required default, see https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-32.md#request-handling
+  @default_service_queue_group "q"
+
   use GenServer
   require Logger
+
 
   @moduledoc """
   A process that can supervise consumers for you
@@ -27,13 +31,43 @@ defmodule Gnat.ConsumerSupervisor do
 
   You can have a single consumer that subscribes to multiple topics or multiple consumers that subscribe to different topics and call different consuming functions. It is recommended that your `ConsumerSupervisor`s are present later in your supervision tree than your `ConnectionSupervisor`. That way during a shutdown the `ConsumerSupervisor` can attempt a graceful shutdown of the consumer before shutting down the connection.
 
+  If you want this consumer supervisor to host a NATS microservice, then you can specify a module that
+  implements the `Gnat.Services.Server` behavior. You'll need to specify the `microservice` field in the consumer
+  supervisor settings and conforms to the `Gnat.Services.Server.service_configuration` type. Here is an example of configuring
+  the consumer supervisor to manage a microservice:
+
+  ```
+  consumer_supervisor_settings = %{
+    connection_name: :name_of_supervised_connection,
+    module: MyApp.Microservice, # a module that implements the Gnat.Services.Server behaviour
+    microservice: %{
+      name: "exampleservice",
+      description: "This is an example microservice",
+      version: "0.1.0",
+      endpoints: [
+        %{
+          name: "add",
+          group_name: "calc",
+        },
+        %{
+          name: "sub",
+          group_name: "calc"
+        }
+      ]
+    }
+  }
+  worker(Gnat.ConsumerSupervisor, [consumer_supervisor_settings, [name: :myservice_consumer]], shutdown: 30_000)
+  ```
+
   It's also possible to pass a `%{consuming_function: {YourModule, :your_function}}` rather than a `:module` in your settings.
-  In that case no error handling or replying is taking care of for you, it will be up to your function to take whatever action you want with each message.
+  In that case no error handling or replying is taking care of for you, microservices cannot be used, and it will be up to your function to take whatever action you want with each message.
   """
+  alias Gnat.Services.ServiceResponder
   @spec start_link(map(), keyword()) :: GenServer.on_start
   def start_link(settings, options \\ []) do
     GenServer.start_link(__MODULE__, settings, options)
   end
+
 
   @impl GenServer
   def init(settings) do
@@ -41,14 +75,17 @@ defmodule Gnat.ConsumerSupervisor do
     {:ok, task_supervisor_pid} = Task.Supervisor.start_link()
     connection_name = Map.get(settings, :connection_name)
     subscription_topics = Map.get(settings, :subscription_topics)
+    microservice = Map.get(settings, :microservice)
 
     state = %{
       connection_name: connection_name,
       connection_pid: nil,
+      svc_responder_pid: nil,
       status: :disconnected,
       subscription_topics: subscription_topics,
       subscriptions: [],
       task_supervisor_pid: task_supervisor_pid,
+      microservice_config: microservice,
     }
 
     cond do
@@ -75,15 +112,13 @@ defmodule Gnat.ConsumerSupervisor do
         {:noreply, state}
       connection_pid ->
         _ref = Process.monitor(connection_pid)
-        subscriptions = Enum.map(state.subscription_topics, fn(topic_and_queue_group) ->
-          topic = Map.fetch!(topic_and_queue_group, :topic)
-          {:ok, subscription} = case Map.get(topic_and_queue_group, :queue_group) do
-            nil -> Gnat.sub(connection_pid, self(), topic)
-            queue_group -> Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
-          end
-          subscription
-        end)
-        {:noreply, %{state | status: :connected, connection_pid: connection_pid, subscriptions: subscriptions}}
+        state = if Map.get(state, :microservice_config) do
+          initialize_as_microservice(state, connection_pid)
+        else
+          initialize_as_manual_consumer(state, connection_pid)
+        end
+
+        {:noreply, %{state | status: :connected, connection_pid: connection_pid}}
     end
   end
 
@@ -100,7 +135,12 @@ defmodule Gnat.ConsumerSupervisor do
   end
 
   def handle_info({:msg, gnat_message}, %{module: module} = state) do
-    Task.Supervisor.async_nolink(state.task_supervisor_pid, Gnat.Server, :execute, [module, gnat_message])
+    if Map.get(state, :microservice_config) do
+      Task.Supervisor.async_nolink(state.task_supervisor_pid, Gnat.Services.Server, :execute, [module, gnat_message, state.svc_responder_pid])
+    else
+      Task.Supervisor.async_nolink(state.task_supervisor_pid, Gnat.Server, :execute, [module, gnat_message])
+    end
+
     {:noreply, state}
   end
 
@@ -148,4 +188,33 @@ defmodule Gnat.ConsumerSupervisor do
         wait_for_empty_task_supervisor(state)
     end
   end
+
+  defp initialize_as_manual_consumer(state, connection_pid) do
+    subscriptions = Enum.map(state.subscription_topics, fn(topic_and_queue_group) ->
+      topic = Map.fetch!(topic_and_queue_group, :topic)
+      {:ok, subscription} = case Map.get(topic_and_queue_group, :queue_group) do
+        nil -> Gnat.sub(connection_pid, self(), topic)
+        queue_group -> Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
+      end
+      subscription
+    end)
+
+    %{ state | subscriptions: subscriptions }
+  end
+
+  defp initialize_as_microservice(state, connection_pid) do
+    {:ok, responder_pid} = ServiceResponder.start_link(%{ state | connection_pid: connection_pid })
+    endpoints = get_in(state, [:microservice_config, :endpoints])
+
+    subscriptions = Enum.map(endpoints, fn(ep) ->
+      subject = ServiceResponder.derive_subscription_subject(ep)
+      queue_group = Map.get(ep, :queue_group, @default_service_queue_group)
+      {:ok, subscription} = Gnat.sub(connection_pid, self(), subject, queue_group: queue_group)
+
+      subscription
+    end)
+
+    %{state | svc_responder_pid: responder_pid, subscriptions: subscriptions }
+  end
+
 end

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -31,18 +31,18 @@ defmodule Gnat.ConsumerSupervisor do
 
   You can have a single consumer that subscribes to multiple topics or multiple consumers that subscribe to different topics and call different consuming functions. It is recommended that your `ConsumerSupervisor`s are present later in your supervision tree than your `ConnectionSupervisor`. That way during a shutdown the `ConsumerSupervisor` can attempt a graceful shutdown of the consumer before shutting down the connection.
 
-  If you want this consumer supervisor to host a NATS microservice, then you can specify a module that
-  implements the `Gnat.Services.Server` behavior. You'll need to specify the `microservice` field in the consumer
+  If you want this consumer supervisor to host a NATS service, then you can specify a module that
+  implements the `Gnat.Services.Server` behavior. You'll need to specify the `service_definition` field in the consumer
   supervisor settings and conforms to the `Gnat.Services.Server.service_configuration` type. Here is an example of configuring
-  the consumer supervisor to manage a microservice:
+  the consumer supervisor to manage a service:
 
   ```
   consumer_supervisor_settings = %{
     connection_name: :name_of_supervised_connection,
-    module: MyApp.Microservice, # a module that implements the Gnat.Services.Server behaviour
-    microservice: %{
+    module: MyApp.Service, # a module that implements the Gnat.Services.Server behaviour
+    service_definition: %{
       name: "exampleservice",
-      description: "This is an example microservice",
+      description: "This is an example service",
       version: "0.1.0",
       endpoints: [
         %{
@@ -75,7 +75,7 @@ defmodule Gnat.ConsumerSupervisor do
     {:ok, task_supervisor_pid} = Task.Supervisor.start_link()
     connection_name = Map.get(settings, :connection_name)
     subscription_topics = Map.get(settings, :subscription_topics)
-    microservice = Map.get(settings, :microservice)
+    microservice = Map.get(settings, :service_definition)
 
     state = %{
       connection_name: connection_name,

--- a/lib/gnat/services/server.ex
+++ b/lib/gnat/services/server.ex
@@ -2,17 +2,17 @@ defmodule Gnat.Services.Server do
   require Logger
 
   @moduledoc """
-  A behavior for acting as a NATS microservice
+  A behavior for acting as a NATS service
 
-  Creating a microservice with this behavior works almost exactly the same as `Gnat.Server`,
+  Creating a service with this behavior works almost exactly the same as `Gnat.Server`,
   with the bonus that this service keeps track of requests, errors, processing time, and
   participates in service discovery and monitoring as defined by
-  the [NATS microservice protocol](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-32.md).
+  the [NATS service protocol](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-32.md).
 
 
   ## Example
 
-      defmodule MyApp.Microservice do
+      defmodule MyApp.Service do
         use Gnat.Services.Server
 
         # Classic subject matching
@@ -71,9 +71,9 @@ alias Gnat.Services.ServiceResponder
 
 
   @typedoc """
-  Service configuration is provided as part of the consumer supervisor settings in the `microservice` field.
-  You can specify _either_ the `subscription_topics` field for a reguar server or the `microservice` field for a
-  new NATS microservice.
+  Service configuration is provided as part of the consumer supervisor settings in the `service_definition` field.
+  You can specify _either_ the `subscription_topics` field for a reguar server or the `service_definition` field for a
+  new NATS service.
 
   * `name` - The name of the service. Needs to conform to the rules for NATS service names
   * `version` - A required version number (w/out "v" prefix) conforming to semver rules

--- a/lib/gnat/services/server.ex
+++ b/lib/gnat/services/server.ex
@@ -1,0 +1,167 @@
+defmodule Gnat.Services.Server do
+  require Logger
+
+  @moduledoc """
+  A behavior for acting as a NATS microservice
+
+  Creating a microservice with this behavior works almost exactly the same as `Gnat.Server`,
+  with the bonus that this service keeps track of requests, errors, processing time, and
+  participates in service discovery and monitoring as defined by
+  the [NATS microservice protocol](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-32.md).
+
+
+  ## Example
+
+      defmodule MyApp.Microservice do
+        use Gnat.Services.Server
+
+        # Classic subject matching
+        def request(%{body: _body, topic: "myservice.req"}, _, _) do
+          {:reply, "handled request"}
+        end
+
+        # Can also match on endpoint or group
+        def request(msg, "add", "calculator") do
+          {:reply, "42"}
+        end
+
+        # defining an error handler is optional, the default one will just call Logger.error for you
+        def error(%{gnat: gnat, reply_to: reply_to}, _error) do
+          Gnat.pub(gnat, reply_to, "Something went wrong and I can't handle your request")
+        end
+      end
+  """
+alias Gnat.Services.ServiceResponder
+
+  @doc """
+  Called when a message is received from the broker. The endpoint on which the message arrived
+  is always supplied. If the endpoint is a member of a group, the group name will also be
+  provided.
+
+  Automatically increments the request time and processing time stats for this service.
+  """
+  @callback request(message::Gnat.message(), endpoint :: String.t(), group :: String.t() | nil) :: :ok | {:reply, iodata()} | {:error, term()}
+
+  @doc """
+  Called when an error occured during the `request/1`. Automatically increments the error count
+  and processing time stats for this service.
+
+  If your `request/1` function returned `{:error, term}`, then the `term` you returned will be passed as the second argument.
+  If an exception was raised during your `request/1` function, then the exception will be passed as the second argument.
+  If your `request/1` function returned something other than the supported return types, then its return value will be passed as the second argument.
+  """
+  @callback error(message::Gnat.message(), error::term()) :: :ok | {:reply, iodata()}
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Gnat.Services.Server
+
+      def error(_message, error) do
+        require Logger
+        Logger.error(
+          "Gnat.Server encountered an error while handling a request: #{inspect(error)}",
+          type: :gnat_server_error,
+          error: error
+        )
+      end
+
+      defoverridable error: 2
+    end
+  end
+
+
+  @typedoc """
+  Service configuration is provided as part of the consumer supervisor settings in the `microservice` field.
+  You can specify _either_ the `subscription_topics` field for a reguar server or the `microservice` field for a
+  new NATS microservice.
+
+  * `name` - The name of the service. Needs to conform to the rules for NATS service names
+  * `version` - A required version number (w/out "v" prefix) conforming to semver rules
+  * `queue_group` - An optional queue group for service subscriptions. If left off, "q" will be used.
+  * `description` - An optional description of the service
+  * `metadata` - An optional arbitrary map of service metadata
+  * `endpoints` - A required list of service endpoints. All services must have at least one endpoint
+  """
+  @type service_configuration :: %{
+    required(:name) =>         binary(),
+    required(:version) =>      binary(),
+    required(:endpoints) =>    [endpoint_configuration()],
+    optional(:queue_group) => binary(),
+    optional(:description) => binary(),
+    optional(:metadata) =>     map(),
+  }
+
+  @typedoc """
+  Each service configuration must contain at least one endpoint. Endpoints can manually specify their
+  subscription subjects or they can be derived from the endpoint name.
+
+  * `subject` - A specific subject for this endpoint to listen on. If this is not provided, then the endpoint name will be used.
+  * `name` - The required name of the endpoint
+  * `group_name` - An optional group to which this endpoint belongs
+  * `queue_group` - A queue group for this endpoint's subscription. If not supplied, "q" will be used.
+  * `metadata` - An optional map containing metadata for this endpoint
+  """
+  @type endpoint_configuration :: %{
+    required(:name) => binary(),
+    optional(:subject) => binary(),
+    optional(:group_name) => binary(),
+    optional(:queue_group) => binary(),
+    optional(:metadata) => map()
+  }
+
+
+  @doc false
+  def execute(module, message, responder_pid) do
+    try do
+      {endpoint, group} = ServiceResponder.lookup_endpoint(responder_pid, message.topic)
+
+      case :timer.tc(fn -> apply(module, :request, [message, endpoint, group]) end) do
+        {_elapsed, :ok} -> :done
+        {elapsed_ns, {:reply, data}} ->
+          send_reply(message, data)
+          :telemetry.execute([:gnat, :service_request], %{latency: elapsed_ns}, %{topic: message.topic, endpoint: endpoint, group: group})
+          ServiceResponder.record_request(responder_pid, message.topic, elapsed_ns )
+        {elapsed_ns, {:error, error}} ->
+          execute_error(module, message, error)
+          :telemetry.execute([:gnat, :service_error], %{latency: elapsed_ns}, %{topic: message.topic, endpoint: endpoint, group: group})
+          ServiceResponder.record_error(responder_pid, message.topic, elapsed_ns, inspect(error))
+        other -> execute_error(module, message, other)
+      end
+
+    rescue e ->
+      execute_error(module, message, e)
+    end
+  end
+
+  @doc false
+  defp execute_error(module, message, error) do
+    try do
+      case apply(module, :error, [message, error]) do
+        :ok -> :done
+        {:reply, data} -> send_reply(message, data)
+        other ->
+          Logger.error(
+            "error handler for #{module} returned something unexpected: #{inspect(other)}",
+            type: :gnat_server_error
+          )
+      end
+
+    rescue e ->
+      Logger.error(
+        "error handler for #{module} encountered an error: #{inspect(e)}",
+        type: :gnat_server_error
+      )
+    end
+  end
+
+  @doc false
+  def send_reply(%{gnat: gnat, reply_to: return_address}, iodata) when is_binary(return_address) do
+    Gnat.pub(gnat, return_address, iodata)
+  end
+  def send_reply(_other, _iodata) do
+    Logger.error(
+      "Could not send reply because no reply_to was provided with the original message",
+      type: :gnat_server_error
+    )
+  end
+end

--- a/lib/gnat/services/server.ex
+++ b/lib/gnat/services/server.ex
@@ -115,7 +115,7 @@ alias Gnat.Services.ServiceResponder
     try do
       {endpoint, group} = ServiceResponder.lookup_endpoint(responder_pid, message.topic)
 
-      case :timer.tc(fn -> apply(module, :request, [message, endpoint, group]) end) do
+      case :timer.tc(fn -> apply(module, :request, [message, endpoint, group]) end, :nanosecond) do
         {_elapsed, :ok} -> :done
         {elapsed_ns, {:reply, data}} ->
           send_reply(message, data)

--- a/lib/gnat/services/server.ex
+++ b/lib/gnat/services/server.ex
@@ -79,7 +79,7 @@ alias Gnat.Services.ServiceResponder
   * `version` - A required version number (w/out "v" prefix) conforming to semver rules
   * `queue_group` - An optional queue group for service subscriptions. If left off, "q" will be used.
   * `description` - An optional description of the service
-  * `metadata` - An optional arbitrary map of service metadata
+  * `metadata` - An optional string->string map of service metadata
   * `endpoints` - A required list of service endpoints. All services must have at least one endpoint
   """
   @type service_configuration :: %{
@@ -99,7 +99,7 @@ alias Gnat.Services.ServiceResponder
   * `name` - The required name of the endpoint
   * `group_name` - An optional group to which this endpoint belongs
   * `queue_group` - A queue group for this endpoint's subscription. If not supplied, "q" will be used.
-  * `metadata` - An optional map containing metadata for this endpoint
+  * `metadata` - An optional string->string map containing metadata for this endpoint
   """
   @type endpoint_configuration :: %{
     required(:name) => binary(),

--- a/lib/gnat/services/service_responder.ex
+++ b/lib/gnat/services/service_responder.ex
@@ -36,7 +36,7 @@ defmodule Gnat.Services.ServiceResponder do
   @spec init(map) :: {:ok, state()} | {:stop, String.t}
   def init(settings) do
     Process.flag(:trap_exit, true)
-    Logger.warning("NATS microservices feature is experimental and subject to change")
+
     if !validate_configuration(Map.get(settings, :microservice_config)) do
       {:stop, "Invalid service configuration"}
     else

--- a/lib/gnat/services/service_responder.ex
+++ b/lib/gnat/services/service_responder.ex
@@ -1,0 +1,257 @@
+defmodule Gnat.Services.ServiceResponder do
+  @moduledoc false
+
+  require Logger
+  alias Gnat.Services.WireProtocol
+  @subscription_subject "$SRV.>"
+  @op_ping "PING"
+  @op_stats "STATS"
+  @op_info "INFO"
+
+  @idx_requests 1
+  @idx_errors 2
+  @idx_processing_time 3
+
+  @name_regex ~r/^[a-zA-Z0-9_-]+$/
+  @version_regex ~r/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+
+  use GenServer
+
+
+  @type state :: %{
+    config: Gnat.Services.Server.service_configuration(),
+    subject_map: map(),
+    connection_pid: pid,
+    instance_id: String.t,
+    subscription: non_neg_integer | String.t,
+    started: String.t
+  }
+
+  @spec start_link(map(), keyword()) :: GenServer.on_start
+  def start_link(settings, options \\ []) do
+    GenServer.start_link(__MODULE__, settings, options)
+  end
+
+  @impl GenServer
+  @spec init(map) :: {:ok, state()} | {:stop, String.t}
+  def init(settings) do
+    Process.flag(:trap_exit, true)
+    Logger.warning("NATS microservices feature is experimental and subject to change")
+    if !validate_configuration(Map.get(settings, :microservice_config)) do
+      {:stop, "Invalid service configuration"}
+    else
+      state = %{
+        config: settings.microservice_config,
+        subject_map: build_subject_map(settings.microservice_config.endpoints),
+        connection_pid: Map.get(settings, :connection_pid),
+        instance_id: :crypto.strong_rand_bytes(12) |> Base.encode64,
+        subscription: nil,
+        started: DateTime.to_iso8601(DateTime.utc_now())
+      }
+
+      {:ok, subscription} = case get_in(state, [:config, :queue_group]) do
+        nil -> Gnat.sub(state.connection_pid, self(), @subscription_subject)
+        queue_group -> Gnat.sub(state.connection_pid, self(), @subscription_subject, queue_group: queue_group)
+      end
+
+      {:ok, %{ state | subscription: subscription }}
+    end
+
+  end
+
+  @impl true
+  def handle_info({:msg, %{topic: topic, body: _body, reply_to: rt, gnat: gnat}}, state) do
+    tokens = String.split(topic, ".")
+    if length(tokens) >= 2 do
+      operation = Enum.at(tokens, 1)
+      tail = tokens |> Enum.slice(2, length(tokens)-2)
+      case operation do
+        @op_ping -> handle_ping(tail, state, rt, gnat)
+        @op_info -> handle_service_info(tail, state, rt, gnat)
+        @op_stats -> handle_stats(tail, state, rt, gnat)
+      end
+    end
+
+    {:noreply, state}
+  end
+
+
+  @impl GenServer
+  def terminate(:shutdown, state) do
+    Logger.info "#{__MODULE__} starting graceful shutdown"
+    Gnat.unsub(state.connection_pid, state.subscription)
+    Logger.info "#{__MODULE__} finished graceful shutdown"
+  end
+  def terminate(reason, _state) do
+    Logger.error "#{__MODULE__} unexpected shutdown #{inspect reason}"
+  end
+
+  def record_request(pid, subject, elapsed_ns) when is_pid(pid), do: GenServer.cast(pid, {:record_request, subject, elapsed_ns})
+  def record_request(_, _,_), do: :ok
+
+  def record_error(pid, subject, elapsed_ns, msg) when is_pid(pid), do: GenServer.cast(pid, {:record_error, subject, elapsed_ns, msg})
+  def record_error(_,_,_,_), do: :ok
+
+  def lookup_endpoint(pid, subject) when is_pid(pid), do: GenServer.call(pid, {:lookup_endpoint, subject})
+
+  @impl true
+  def handle_cast({:record_request, subject, elapsed_ns}, state) do
+    counters = case :ets.lookup(:endpoint_stats, subject) do
+      [{^subject, counters, _last_error}] ->
+        counters
+      [] ->
+        c = :counters.new(3, [:atomics])
+        :ets.insert(:endpoint_stats, {subject, c, nil})
+        c
+    end
+    :counters.add(counters, @idx_requests, 1)
+    :counters.add(counters, @idx_processing_time, elapsed_ns)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:record_error, subject, elapsed_ns, msg}, state) do
+    counters = case :ets.lookup(:endpoint_stats, subject) do
+      [{^subject, counters, _last_error}] ->
+        counters
+      [] ->
+        c = :counters.new(3, [:atomics])
+        :ets.insert(:endpoint_stats, {subject, c, nil})
+        c
+    end
+    :counters.add(counters, @idx_errors, 1)
+    :counters.add(counters, @idx_processing_time, elapsed_ns)
+    :ets.insert(:endpoint_stats, {subject, counters, msg})
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call({:lookup_endpoint, subject}, _from, state) do
+    res = case Map.get(state.subject_map, subject) do
+      nil ->
+        {nil, nil}
+      {epname, groupname} ->
+        {epname, groupname}
+    end
+    {:reply, res, state}
+  end
+
+  defp handle_ping(tail, state, rt, gnat) do
+    if should_respond(tail, state.config.name, state.instance_id) do
+      output = %WireProtocol.PingResponse{
+        name: state.config.name,
+        id: state.instance_id,
+        version: state.config.version,
+        metadata: get_in(state, [:config, :metadata])
+      }
+
+      Gnat.pub(gnat, rt, Jason.encode!(output))
+    end
+  end
+
+  defp handle_service_info(tail, state, rt, gnat) do
+    if should_respond(tail, state.config.name, state.instance_id) do
+      output = %WireProtocol.InfoResponse{
+        name: state.config.name,
+        description: state.config.description,
+        id: state.instance_id,
+        version: state.config.version,
+        endpoints: state.config.endpoints |> Enum.map(fn ep ->
+          %{
+            name: ep.name,
+            subject: ep.subject,
+            metadata: Map.get(ep, :metadata, %{}),
+            queue_group: Map.get(ep, :queue_group)
+          }
+        end)
+      }
+
+      Gnat.pub(gnat, rt, Jason.encode!(output))
+    end
+
+  end
+
+  defp handle_stats(tail, state, rt, gnat) do
+    if should_respond(tail, state.config.name, state.instance_id) do
+      output = %WireProtocol.StatsResponse{
+        name: state.config.name,
+        id: state.instance_id,
+        version: state.config.version,
+        started: state.started,
+        endpoints: Enum.map(state.config.endpoints, fn(ep) ->
+          effective_subject = derive_subscription_subject(ep)
+          {counters, last_error} = case :ets.lookup(:endpoint_stats, effective_subject) do
+            [{^effective_subject, counters, last_error}] ->
+              {counters, last_error}
+            [] ->
+              {:counters.new(3, [:atomics]), nil}
+          end
+          processing_time = :counters.get(counters, @idx_processing_time)
+          num_errors = :counters.get(counters, @idx_errors)
+          num_requests = :counters.get(counters, @idx_requests)
+          total_calls = num_errors + num_requests
+          avg = if total_calls > 0 do
+            trunc(ceil(processing_time / total_calls))
+          else
+            0
+          end
+
+          %{
+            name: ep.name,
+            subject: Map.get(ep, :subject),
+            num_requests: num_requests,
+            num_errors: num_errors,
+            last_error: last_error,
+            processing_time: processing_time,
+            average_processing_time: avg,
+            queue_group: Map.get(ep, :queue_group),
+            data: %{}
+          }
+        end)
+      }
+
+      Gnat.pub(gnat, rt, Jason.encode!(output))
+    end
+  end
+
+  @spec should_respond(list, String.t, String.t) :: boolean()
+  defp should_respond(tail, service_name, instance_id) do
+    case tail do
+      [] -> true
+      [^service_name] -> true
+      [^service_name, ^instance_id] -> true
+      _ -> false
+    end
+  end
+
+  defp validate_configuration(configuration) when is_nil(configuration), do: false
+  defp validate_configuration(configuration) when not is_map(configuration), do: false
+  defp validate_configuration(configuration) do
+    version = Map.get(configuration, :version)
+    name = Map.get(configuration, :name)
+
+    String.match?(version, @version_regex) && String.match?(name, @name_regex) &&
+      length(Map.get(configuration, :endpoints, [])) > 0
+  end
+
+  @spec derive_subscription_subject(Gnat.Services.Server.endpoint_configuration()) :: String.t
+  def derive_subscription_subject(endpoint) do
+    group_prefix = case Map.get(endpoint, :group_name) do
+      nil -> ""
+      prefix -> "#{prefix}."
+    end
+    subject = case Map.get(endpoint, :subject) do
+      nil -> endpoint.name
+      sub -> sub
+    end
+    "#{group_prefix}#{subject}"
+  end
+
+  defp build_subject_map(endpoints) do
+    endpoints |> Enum.map(fn ep ->
+      { derive_subscription_subject(ep), {ep.name, ep.group_name}}
+    end) |> Map.new()
+  end
+end

--- a/lib/gnat/services/service_responder.ex
+++ b/lib/gnat/services/service_responder.ex
@@ -272,9 +272,9 @@ defmodule Gnat.Services.ServiceResponder do
 
   defp valid_metadata?(nil), do: :ok
   defp valid_metadata?(md) do
-    bads = Map.filter(md, fn {k, v} ->
+    bads = Enum.filter(md, fn {k, v} ->
       !is_binary(k) or !is_binary(v)
-    end) |> map_size()
+    end) |> length()
 
     if bads == 0 do
       :ok

--- a/lib/gnat/services/wire_protocol.ex
+++ b/lib/gnat/services/wire_protocol.ex
@@ -1,0 +1,99 @@
+defmodule Gnat.Services.WireProtocol do
+  @moduledoc false
+
+  defmodule InfoResponse do
+    @moduledoc false
+    @info_response_type "io.nats.micro.v1.info_response"
+
+    @type endpoint :: %{
+      name:       String.t,
+      subject:    String.t,
+      metadata:   map(),
+      queue_group: String.t
+    }
+
+    @type t :: %__MODULE__{
+      name:         String.t,
+      id:           String.t,
+      version:      String.t,
+      description:  String.t,
+      metadata:     map(),
+      endpoints:    [endpoint()],
+      type:         String.t
+    }
+
+    @derive Jason.Encoder
+    @enforce_keys [:name, :id, :version]
+    defstruct [
+                :name,
+                :id,
+                :version,
+                :metadata,
+                :description,
+                endpoints: [],
+                type: @info_response_type
+    ]
+
+  end
+
+  defmodule PingResponse do
+    @moduledoc false
+    @ping_response_type "io.nats.micro.v1.ping_response"
+
+    @type t :: %__MODULE__{
+      name:     String.t,
+      id:       String.t,
+      version:  String.t,
+      metadata: map()
+    }
+
+    @derive Jason.Encoder
+    @enforce_keys [:name, :id, :version]
+    defstruct [
+        :name,
+        :id,
+        :version,
+        :metadata,
+        type: @ping_response_type
+    ]
+  end
+
+  defmodule StatsResponse do
+    @moduledoc false
+    @stats_response_type "io.nats.micro.v1.stats_response"
+
+    @type endpoint :: %{
+      name:                     String.t,
+      subject:                  String.t,
+      num_requests:             integer,
+      num_errors:               integer,
+      last_error:               String.t,
+      processing_time:          integer,
+      average_processing_time:  integer,
+      queue_group:              String.t,
+      data:                     map()
+    }
+
+    @type t :: %__MODULE__{
+      name:       String.t,
+      id:         String.t,
+      version:    String.t,
+      metadata:   map(),
+      started:    String.t,
+      endpoints:  [endpoint()],
+      type:       String.t
+    }
+
+    @derive Jason.Encoder
+    @enforce_keys [:name, :id]
+    defstruct [
+        :name,
+        :id,
+        :version,
+        :metadata,
+        :started,
+        :endpoints,
+        type: @stats_response_type
+    ]
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nats-io/nats.ex"
-  @version "1.6.0"
+  @version "1.7.0"
 
   def project do
     [
@@ -62,7 +62,8 @@ defmodule Gnat.Mixfile do
         "Steve Newell",
         "Michael Ries",
         "Garrett Thornburg",
-        "Masahiro Tokioka"
+        "Masahiro Tokioka",
+        "Kevin Hoffman"
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Gnat.Mixfile do
     [
       app: :gnat,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/gnat/consumer_supervisor_test.exs
+++ b/test/gnat/consumer_supervisor_test.exs
@@ -14,4 +14,32 @@ defmodule Gnat.ConsumerSupervisorTest do
   test "catches raised errors" do
     assert {:ok, %{body: "500 error"}} = Gnat.request(:test_connection, "example.raise", "hi")
   end
+
+  test "microservice endpoint add works" do
+    assert {:ok, %{body: "6"}} = Gnat.request(:test_connection, "calc.add", "foo")
+  end
+
+  test "microservice endpoint sub works" do
+    assert {:ok, %{body: "4"}} = Gnat.request(:test_connection, "calc.sub", "foo")
+  end
+
+  test "microservice endpoint errors properly" do
+    assert {:ok, %{body: "500 error"}} = Gnat.request(:test_connection, "calc.sub", "error")
+  end
+
+  test "microservice endpoint counters working" do
+    # at least 1 error, at least 1 request, non-zero processing time
+    assert {:ok, %{body: "4"}} = Gnat.request(:test_connection, "calc.sub", "foo")
+    assert {:ok, %{body: "6"}} = Gnat.request(:test_connection, "calc.add", "foo")
+    assert {:ok, %{body: "500 error"}} = Gnat.request(:test_connection, "calc.sub", "error")
+
+    {:ok, %{body: body}} = Gnat.request(:test_connection, "$SRV.STATS.exampleservice", "")
+    payload = Jason.decode!(body, keys: :atoms)
+    assert Enum.at(payload.endpoints, 0) |> Map.get(:processing_time) > 1000
+    assert Enum.at(payload.endpoints, 0) |> Map.get(:num_requests) > 0
+
+    assert Enum.at(payload.endpoints, 1) |> Map.get(:processing_time) > 1000
+    assert Enum.at(payload.endpoints, 1) |> Map.get(:num_requests) > 0
+
+  end
 end

--- a/test/gnat/consumer_supervisor_test.exs
+++ b/test/gnat/consumer_supervisor_test.exs
@@ -1,4 +1,5 @@
 defmodule Gnat.ConsumerSupervisorTest do
+  alias Gnat.Services.ServiceResponder
   use ExUnit.Case, async: true
 
   # these requests are being handled by `ExampleServer` in the `test_helper.exs` file
@@ -27,7 +28,7 @@ defmodule Gnat.ConsumerSupervisorTest do
     assert {:ok, %{body: "500 error"}} = Gnat.request(:test_connection, "calc.sub", "error")
   end
 
-  test "microservice endpoint counters working" do
+  test "service endpoint counters working" do
     # at least 1 error, at least 1 request, non-zero processing time
     assert {:ok, %{body: "4"}} = Gnat.request(:test_connection, "calc.sub", "foo")
     assert {:ok, %{body: "6"}} = Gnat.request(:test_connection, "calc.add", "foo")
@@ -40,6 +41,50 @@ defmodule Gnat.ConsumerSupervisorTest do
 
     assert Enum.at(payload.endpoints, 1) |> Map.get(:processing_time) > 1000
     assert Enum.at(payload.endpoints, 1) |> Map.get(:num_requests) > 0
+
+  end
+
+  test "service endpoint validates service definition" do
+    badv = %{
+      name: "exampleservice",
+      description: "This is an example service",
+      version: "0.1",
+      endpoints: [
+        %{
+          name: "add",
+          group_name: "calc",
+          metadata: %{ :blarg => :thisisbad }
+        },
+        %{
+          name: "sub",
+          group_name: "calc"
+        }
+      ]
+    }
+
+    badv2 = %{
+      name: "exampleservice",
+      description: "This is an example service",
+      version: "0.1.0",
+      endpoints: [
+        %{
+          name: "add stuff up",
+          group_name: "calc",
+        },
+        %{
+          name: "sub",
+          group_name: "calc"
+        }
+      ]
+    }
+
+    assert ServiceResponder.validate_configuration(badv) ==
+      {:error, ["Version '0.1' does not conform to semver specification",
+                "At least one key or value found in metadata that was not a string"
+              ]}
+
+    assert ServiceResponder.validate_configuration(badv2) ==
+      {:error, ["Endpoint name 'add stuff up' is not valid"]}
 
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,7 +32,7 @@ defmodule RpcEndpoint do
 end
 spawn(&RpcEndpoint.init/0)
 
-defmodule ExampleMicroservice do
+defmodule ExampleService do
   use Gnat.Services.Server
 
   def request(%{topic: "calc.add", body: body}, _endpoint, _group) when body == "foo" do
@@ -95,10 +95,10 @@ end
 
 {:ok , _pid} = Gnat.ConsumerSupervisor.start_link(%{
   connection_name: :test_connection,
-  module: ExampleMicroservice,
+  module: ExampleService,
   service_definition: %{
     name: "exampleservice",
-    description: "This is an example microservice",
+    description: "This is an example service",
     version: "0.1.0",
     endpoints: [
       %{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -96,7 +96,7 @@ end
 {:ok , _pid} = Gnat.ConsumerSupervisor.start_link(%{
   connection_name: :test_connection,
   module: ExampleMicroservice,
-  microservice: %{
+  service_definition: %{
     name: "exampleservice",
     description: "This is an example microservice",
     version: "0.1.0",

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,14 +36,14 @@ defmodule ExampleService do
   use Gnat.Services.Server
 
   def request(%{topic: "calc.add", body: body}, _endpoint, _group) when body == "foo" do
-    :timer.sleep(100)
+    :timer.sleep(10)
 
     {:reply, "6"}
   end
 
   def request(%{body: body}, "sub", "calc") when body == "foo" do
     # want some processing time to show up
-    :timer.sleep(100)
+    :timer.sleep(10)
     {:reply, "4"}
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -32,6 +32,30 @@ defmodule RpcEndpoint do
 end
 spawn(&RpcEndpoint.init/0)
 
+defmodule ExampleMicroservice do
+  use Gnat.Services.Server
+
+  def request(%{topic: "calc.add", body: body}, _endpoint, _group) when body == "foo" do
+    :timer.sleep(100)
+
+    {:reply, "6"}
+  end
+
+  def request(%{body: body}, "sub", "calc") when body == "foo" do
+    # want some processing time to show up
+    :timer.sleep(100)
+    {:reply, "4"}
+  end
+
+  def request(_, _, _) do
+    {:error, "oops"}
+  end
+
+  def error(_msg, "oops") do
+    {:reply, "500 error"}
+  end
+end
+
 defmodule ExampleServer do
   use Gnat.Server
 
@@ -67,6 +91,26 @@ end
   subscription_topics: [
     %{topic: "example.*"}
   ]
+})
+
+{:ok , _pid} = Gnat.ConsumerSupervisor.start_link(%{
+  connection_name: :test_connection,
+  module: ExampleMicroservice,
+  microservice: %{
+    name: "exampleservice",
+    description: "This is an example microservice",
+    version: "0.1.0",
+    endpoints: [
+      %{
+        name: "add",
+        group_name: "calc",
+      },
+      %{
+        name: "sub",
+        group_name: "calc"
+      }
+    ]
+  }
 })
 
 defmodule CheckForExpectedNatsServers do


### PR DESCRIPTION
* Adds support for creating microservices - developer experience is nearly identical to regular `Gnat.Server`
  * automatically adds responder for ping, stats, and info
* Fills out a few of the sparse areas of documentation
* Fixes some broken links in the docs
* Adds service request and service error to telemetry 

It's been a while since I've written some Elixir so apologies in advance if I've dumped a bunch of non-idiomatic code in this PR