### PR TITLE
Avoid flakey tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,10 @@ jobs:
             elixir: "1.12"
             nats: "2.10.0"
 
+          - otp: "26.2.4"
+            elixir: "1.16.2"
+            nats: "2.10.14"
+
           - otp: "24.3.4"
             elixir: "main"
             nats: "latest"

--- a/test/gnat/consumer_supervisor_test.exs
+++ b/test/gnat/consumer_supervisor_test.exs
@@ -148,7 +148,14 @@ defmodule Gnat.ConsumerSupervisorTest do
     assert message =~ "At least one key or value found in metadata that was not a string"
   end
 
+  # In OTP 26 the GenServer.init behavior changed to do a process EXIT when returning a
+  # {:stop, error} in GenServer.init
+  # We inherit this behavior, so for the purpose of testing, we trap those process exits
+  # to make sure we can process the `{:error, error}` tuple before the process exit kills
+  # our ExUnit test
   defp start_service_supervisor(service_config) do
+    Process.flag(:trap_exit, true)
+
     config = %{
       connection_name: :something,
       module: ExampleService,

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -167,7 +167,7 @@ defmodule Gnat.Jetstream.API.StreamTest do
     test "decodes message data" do
       stream = %Stream{name: "GET_MESSAGE_TEST", subjects: ["GET_MESSAGE_TEST.foo"]}
       assert {:ok, _response} = Stream.create(:gnat, stream)
-      assert :ok = Gnat.pub(:gnat, "GET_MESSAGE_TEST.foo", "hi there")
+      assert {:ok, _} = Gnat.request(:gnat, "GET_MESSAGE_TEST.foo", "hi there")
 
       assert {:ok, response} =
                Stream.get_message(:gnat, "GET_MESSAGE_TEST", %{
@@ -194,8 +194,8 @@ defmodule Gnat.Jetstream.API.StreamTest do
 
       assert {:ok, _response} = Stream.create(:gnat, stream)
 
-      assert :ok =
-               Gnat.pub(:gnat, "GET_MESSAGE_TEST_WITH_HEADERS.bar", "hi there",
+      assert {:ok, %{body: _body}} =
+               Gnat.request(:gnat, "GET_MESSAGE_TEST_WITH_HEADERS.bar", "hi there",
                  headers: [{"foo", "bar"}]
                )
 
@@ -214,7 +214,7 @@ defmodule Gnat.Jetstream.API.StreamTest do
     test "clears the stream" do
       stream = %Stream{name: "PURGE_TEST", subjects: ["PURGE_TEST.foo"]}
       assert {:ok, _response} = Stream.create(:gnat, stream)
-      assert :ok = Gnat.pub(:gnat, "PURGE_TEST.foo", "hi there")
+      assert {:ok, _} = Gnat.request(:gnat, "PURGE_TEST.foo", "hi there")
 
       assert :ok = Stream.purge(:gnat, "PURGE_TEST")
 


### PR DESCRIPTION
While reviewing #152 I ran across a few cases where CI produced flakey results. This PR handles some of the race conditions to make the test suite more dependable.