### PR TITLE
Emitting `:key_deleted` when key is purged

### DIFF
--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -257,13 +257,13 @@ defmodule Gnat.Jetstream.API.KV do
   ## Parameters
   - `headers` - a list of headers to test
 
-  ## Example
+  ## Examples
 
-      iex> is_delete_operation([{"kv-operation", "DEL"}])
+      iex> is_delete_operation?([{"kv-operation", "DEL"}])
       true
-      iex> is_delete_operation([{"kv-operation", "PURGE"}])
+      iex> is_delete_operation?([{"kv-operation", "PURGE"}])
       true
-      iex> is_delete_operation([{"kv-operation", "ADD"}])
+      iex> is_delete_operation?([{"kv-operation", "ADD"}])
       true
   """
   @spec is_delete_operation?(headers :: Gnat.headers()) :: boolean()

--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -264,7 +264,7 @@ defmodule Gnat.Jetstream.API.KV do
       iex> is_delete_operation?([{"kv-operation", "PURGE"}])
       true
       iex> is_delete_operation?([{"kv-operation", "ADD"}])
-      true
+      false
   """
   @spec is_delete_operation?(headers :: Gnat.headers()) :: boolean()
   def is_delete_operation?(headers) do

--- a/lib/gnat/jetstream/api/kv/watcher.ex
+++ b/lib/gnat/jetstream/api/kv/watcher.ex
@@ -10,9 +10,6 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
 
   alias Gnat.Jetstream.API.{Consumer, KV, Util}
 
-  @operation_header "kv-operation"
-  @operation_del "DEL"
-
   @type keywatch_handler ::
           (action :: :key_deleted | :key_added, key :: String.t(), value :: any() -> nil)
 
@@ -54,7 +51,7 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
   def handle_info({:msg, %{topic: key, body: body, headers: headers}}, state) do
     key = KV.subject_to_key(key, state.bucket_name)
 
-    if {@operation_header, @operation_del} in headers do
+    if KV.is_delete_operation?(headers) do
       state.handler.(:key_deleted, key, body)
     end
 

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -104,9 +104,17 @@ defmodule Gnat.Jetstream.API.KVTest do
       KV.put_value(:gnat, bucket, "baz", "quz")
       assert_receive({:key_added, "baz", "quz"})
 
+      KV.put_value(:gnat, bucket, "quz", "qux")
+      assert_receive({:key_added, "quz", "qux"})
+
       KV.delete_key(:gnat, bucket, "baz")
       # key deletions don't carry the data removed
       assert_receive({:key_deleted, "baz", ""})
+
+      # ensure we get delete event on purge
+      KV.purge_key(:gnat, bucket, "quz")
+      assert_receive({:key_deleted, "quz", ""})
+
 
       KV.unwatch(watcher_pid)
 


### PR DESCRIPTION
- Now `:key_deleted` event is emitted when wither purging or deleting a key
- Moved operations module attributes to KV module for better readability

Fixes #156 