### PR TITLE
Soft deprecate is_kv_bucket_stream?/1 in favor of kv_bucket_stream?/1

### DIFF
--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -270,7 +270,7 @@ defmodule Gnat.Jetstream.API.KV do
   end
 
   @spec is_kv_bucket_stream?(stream_name :: binary()) :: boolean()
-  @deprecated "Use Gnat.Jetstream.API.KV.kv_bucket_stream?1 instead"
+  @deprecated "Use Gnat.Jetstream.API.KV.kv_bucket_stream?/1 instead"
   def is_kv_bucket_stream?(stream_name) do
     kv_bucket_stream?(stream_name)
   end

--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -233,7 +233,11 @@ defmodule Gnat.Jetstream.API.KV do
       end)
   """
   def watch(conn, bucket_name, handler) do
-    Gnat.Jetstream.API.KV.Watcher.start_link(conn: conn, bucket_name: bucket_name, handler: handler)
+    Gnat.Jetstream.API.KV.Watcher.start_link(
+      conn: conn,
+      bucket_name: bucket_name,
+      handler: handler
+    )
   end
 
   @doc ~S"""
@@ -265,14 +269,20 @@ defmodule Gnat.Jetstream.API.KV do
     end
   end
 
+  @spec is_kv_bucket_stream?(stream_name :: binary()) :: boolean()
+  @deprecated "Use Gnat.Jetstream.API.KV.kv_bucket_stream?1 instead"
+  def is_kv_bucket_stream?(stream_name) do
+    kv_bucket_stream?(stream_name)
+  end
+
   @doc """
   Returns true if the provided stream is a KV bucket, false otherwise
 
   ## Parameters
   * `stream_name` - the stream name to test
   """
-  @spec is_kv_bucket_stream?(stream_name :: binary()) :: boolean()
-  def is_kv_bucket_stream?(stream_name) do
+  @spec kv_bucket_stream?(stream_name :: binary()) :: boolean()
+  def kv_bucket_stream?(stream_name) do
     String.starts_with?(stream_name, "KV_")
   end
 
@@ -285,19 +295,19 @@ defmodule Gnat.Jetstream.API.KV do
       stream_names =
         streams
         |> Enum.flat_map(fn bucket ->
-          if is_kv_bucket_stream?(bucket) do
-             [bucket |> String.trim_leading(@stream_prefix)]
+          if kv_bucket_stream?(bucket) do
+            [bucket |> String.trim_leading(@stream_prefix)]
           else
-             []
+            []
           end
         end)
+
       {:ok, stream_names}
     else
       {:error, reason} ->
         {:error, reason}
     end
   end
-
 
   @doc false
   def stream_name(bucket_name) do


### PR DESCRIPTION
the `is_` prefix is [reserved for guards](https://hexdocs.pm/elixir/1.18.1/naming-conventions.html#is_-prefix-is_foo) by convention. This PR aligns the function name with the convention for [functions that return booleans](https://hexdocs.pm/elixir/1.18.1/naming-conventions.html#trailing-question-mark-foo)