### PR TITLE
Remove function_exported? check for Keyword.validate!/2

### DIFF
--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -16,36 +16,18 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
 
   defstruct @enforce_keys
 
-  # Remove this hackery when we will support Elixir ~> 1.13 only.
-  if Kernel.function_exported?(Keyword, :validate!, 2) do
-    def validate!(connection_options) do
-      struct!(
-        __MODULE__,
-        Keyword.validate!(connection_options, [
-          :connection_name,
-          :stream_name,
-          :consumer_name,
-          connection_retry_timeout: @default_retry_timeout,
-          connection_retries: @default_retries,
-          inbox_prefix: nil,
-          domain: nil
-        ])
-      )
-    end
-  else
-    def validate!(connection_options) do
-      struct!(
-        __MODULE__,
-        Keyword.merge(
-          [
-            connection_retry_timeout: @default_retry_timeout,
-            connection_retries: @default_retries,
-            inbox_prefix: nil,
-            domain: nil
-          ],
-          connection_options
-        )
-      )
-    end
+  def validate!(connection_options) do
+    struct!(
+      __MODULE__,
+      Keyword.validate!(connection_options, [
+        :connection_name,
+        :stream_name,
+        :consumer_name,
+        connection_retry_timeout: @default_retry_timeout,
+        connection_retries: @default_retries,
+        inbox_prefix: nil,
+        domain: nil
+      ])
+    )
   end
 end


### PR DESCRIPTION
Gnat already requires Elixir 1.14, so we're safe to remove