### PR TITLE
Gnat.Jetstream.API.KV.info/3

### DIFF
--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -226,6 +226,18 @@ defmodule Gnat.Jetstream.API.KV do
     end
   end
 
+  @doc """
+  Information about the state of the bucket's Stream.
+
+  ## Opts
+  * `:domain` - (default `nil`) the domain of the bucket
+  """
+  @spec info(conn :: Gnat.t(), bucket_name :: binary(), keyword()) ::
+          {:ok, Stream.info()} | {:error, any()}
+  def info(conn, bucket_name, opts \\ []) do
+    Stream.info(conn, @stream_prefix <> bucket_name, Keyword.get(opts, :domain))
+  end
+
   @doc ~S"""
   Starts a monitor for key changes in a given bucket. Supply a handler that will receive
   key change notifications.

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -155,6 +155,7 @@ defmodule Gnat.Jetstream.API.KVTest do
       :ok = KV.delete_bucket(:gnat, bucket)
     end
   end
+
   describe "list_buckets/2" do
     test "list buckets when none exists" do
       assert {:ok, []} = KV.list_buckets(:gnat)
@@ -170,10 +171,23 @@ defmodule Gnat.Jetstream.API.KVTest do
 
     test "ignore streams that are not buckets" do
       assert {:ok, %{config: _config}} = KV.create_bucket(:gnat, "TEST_BUCKET_1")
-      stream = %Stream{name: "TEST_STREAM_1", subjects: ["TEST_STREAM_1.subject1", "TEST_STREAM_1.subject2"]}
+
+      stream = %Stream{
+        name: "TEST_STREAM_1",
+        subjects: ["TEST_STREAM_1.subject1", "TEST_STREAM_1.subject2"]
+      }
+
       assert {:ok, _response} = Stream.create(:gnat, stream)
       assert {:ok, ["TEST_BUCKET_1"]} = KV.list_buckets(:gnat)
       :ok = KV.delete_bucket(:gnat, "TEST_BUCKET_1")
+    end
+  end
+
+  describe "info/3" do
+    test "returns bucket info" do
+      assert {:ok, _} = KV.create_bucket(:gnat, "TEST_BUCKET_1")
+      assert {:ok, %{config: %{name: "KV_TEST_BUCKET_1"}}} = KV.info(:gnat, "TEST_BUCKET_1")
+      assert {:error, %{"code" => 404}} = KV.info(:gnat, "NOT_A_BUCKET")
     end
   end
 end

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -187,6 +187,7 @@ defmodule Gnat.Jetstream.API.KVTest do
     test "returns bucket info" do
       assert {:ok, _} = KV.create_bucket(:gnat, "TEST_BUCKET_1")
       assert {:ok, %{config: %{name: "KV_TEST_BUCKET_1"}}} = KV.info(:gnat, "TEST_BUCKET_1")
+      :ok = KV.delete_bucket(:gnat, "TEST_BUCKET_1")
       assert {:error, %{"code" => 404}} = KV.info(:gnat, "NOT_A_BUCKET")
     end
   end


### PR DESCRIPTION
Adds a convenience function for getting info of buckets.

As a note, I think that `Stream.info/3` should be changed to take a keyword list. We can support the case where its nil/binary still