### PR TITLE
fix: unknown field domain in Stream.create

### DIFF
--- a/lib/gnat/jetstream/api/stream.ex
+++ b/lib/gnat/jetstream/api/stream.ex
@@ -68,7 +68,7 @@ defmodule Gnat.Jetstream.API.Stream do
   import Gnat.Jetstream.API.Util
 
   @enforce_keys [:name, :subjects]
-  @derive Jason.Encoder
+  @derive {Jason.Encoder, except: [:domain]}
   defstruct [
     :description,
     :mirror,


### PR DESCRIPTION
I noticed a lot of warnings in the local nats server when running `mix test`:

```
[1] 2025/06/15 08:30:08.523129 [WRN] 172.17.0.1:58290 - cid:886 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.pager_a': json: unknown field "domain"
[1] 2025/06/15 08:30:09.385284 [WRN] 172.17.0.1:52226 - cid:895 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.astream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.467124 [WRN] 172.17.0.1:52324 - cid:911 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.delstream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.475414 [WRN] 172.17.0.1:52348 - cid:916 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.anewstream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.479769 [WRN] 172.17.0.1:52364 - cid:920 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.update_test_stream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.481512 [WRN] 172.17.0.1:52364 - cid:920 - Invalid JetStream request '$G > $JS.API.STREAM.UPDATE.update_test_stream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.485537 [WRN] 172.17.0.1:52366 - cid:924 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.pstream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.491048 [WRN] 172.17.0.1:52368 - cid:928 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.infostream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.501216 [WRN] 172.17.0.1:52382 - cid:933 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.purgestream': json: unknown field "domain"
[1] 2025/06/15 08:30:09.510820 [WRN] 172.17.0.1:52400 - cid:938 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.STREAM4': json: unknown field "domain"
[1] 2025/06/15 08:30:09.523867 [WRN] 172.17.0.1:52416 - cid:945 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.REQUEST_MESSAGE_TEST_STREAM': json: unknown field "domain"
[1] 2025/06/15 08:30:09.681304 [WRN] 172.17.0.1:52428 - cid:951 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.STREAM1': json: unknown field "domain"
[1] 2025/06/15 08:30:10.158957 [WRN] 172.17.0.1:52490 - cid:977 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_TEST_BUCKET_1': json: unknown field "domain"
[1] 2025/06/15 08:30:10.160928 [WRN] 172.17.0.1:52490 - cid:977 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_TEST_BUCKET_2': json: unknown field "domain"
[1] 2025/06/15 08:30:10.167636 [WRN] 172.17.0.1:52492 - cid:984 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_CREATE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.176779 [WRN] 172.17.0.1:52508 - cid:988 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.TEST_STREAM_1': json: unknown field "domain"
[1] 2025/06/15 08:30:10.183083 [WRN] 172.17.0.1:52512 - cid:995 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_OTHER_TTL_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.188772 [WRN] 172.17.0.1:52524 - cid:999 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_LIST_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.590884 [WRN] 172.17.0.1:52562 - cid:1019 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_BUCKET_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.596409 [WRN] 172.17.0.1:52574 - cid:1023 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_TTL_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.608562 [WRN] 172.17.0.1:52582 - cid:1028 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_WATCH_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.710869 [WRN] 172.17.0.1:52590 - cid:1034 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_PURGE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.717225 [WRN] 172.17.0.1:52598 - cid:1038 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_PUT_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:10.728569 [WRN] 172.17.0.1:52616 - cid:1043 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.KV_KEY_DELETE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.186649 [WRN] 172.17.0.1:52658 - cid:1065 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.LIST_OFFSET_TEST_ONE': json: unknown field "domain"
[1] 2025/06/15 08:30:11.188380 [WRN] 172.17.0.1:52658 - cid:1065 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.LIST_OFFSET_TEST_TWO': json: unknown field "domain"
[1] 2025/06/15 08:30:11.194903 [WRN] 172.17.0.1:52670 - cid:1072 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.LIST_SUBJECT_TEST_ONE': json: unknown field "domain"
[1] 2025/06/15 08:30:11.197001 [WRN] 172.17.0.1:52670 - cid:1072 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.LIST_SUBJECT_TEST_TWO': json: unknown field "domain"
[1] 2025/06/15 08:30:11.204090 [WRN] 172.17.0.1:52680 - cid:1079 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.ARGS_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.208906 [WRN] 172.17.0.1:52684 - cid:1083 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.LIST_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.224361 [WRN] 172.17.0.1:52718 - cid:1095 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.GET_MESSAGE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.230070 [WRN] 172.17.0.1:52730 - cid:1099 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.INFO_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.238730 [WRN] 172.17.0.1:52754 - cid:1104 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.DISCARD_NEW_PER_SUBJECT_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.247189 [WRN] 172.17.0.1:52764 - cid:1108 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.UPDATE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.248835 [WRN] 172.17.0.1:52764 - cid:1108 - Invalid JetStream request '$G > $JS.API.STREAM.UPDATE.UPDATE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.253281 [WRN] 172.17.0.1:52774 - cid:1112 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.GET_MESSAGE_TEST_WITH_HEADERS': json: unknown field "domain"
[1] 2025/06/15 08:30:11.260260 [WRN] 172.17.0.1:52778 - cid:1116 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.PURGE_TEST': json: unknown field "domain"
[1] 2025/06/15 08:30:11.276302 [WRN] 172.17.0.1:52804 - cid:1121 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_MY-STORE': json: unknown field "domain"
[1] 2025/06/15 08:30:11.286911 [WRN] 172.17.0.1:52814 - cid:1126 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_TEST_BUCKET_1': json: unknown field "domain"
[1] 2025/06/15 08:30:11.289090 [WRN] 172.17.0.1:52814 - cid:1126 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_TEST_BUCKET_2': json: unknown field "domain"
[1] 2025/06/15 08:30:11.298886 [WRN] 172.17.0.1:52824 - cid:1133 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.TEST_STREAM_1': json: unknown field "domain"
[1] 2025/06/15 08:30:11.304266 [WRN] 172.17.0.1:52836 - cid:1137 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_PtIi7npURX6CI4zr': json: unknown field "domain"
[1] 2025/06/15 08:30:11.412881 [WRN] 172.17.0.1:52854 - cid:1147 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_-OUXateU6vhKXK1H': json: unknown field "domain"
[1] 2025/06/15 08:30:11.418330 [WRN] 172.17.0.1:52856 - cid:1151 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_INF': json: unknown field "domain"
[1] 2025/06/15 08:30:11.431900 [WRN] 172.17.0.1:52880 - cid:1156 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_jFdZ07r0JjA5wg3i': json: unknown field "domain"
[1] 2025/06/15 08:30:11.535136 [WRN] 172.17.0.1:52898 - cid:1166 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_bptCmCTtEJAkabN_': json: unknown field "domain"
[1] 2025/06/15 08:30:11.723046 [WRN] 172.17.0.1:52908 - cid:1174 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_i7mjQTpBN74w59c3': json: unknown field "domain"
[1] 2025/06/15 08:30:11.826021 [WRN] 172.17.0.1:52920 - cid:1180 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_JN9o5JfW49qqwVpW': json: unknown field "domain"
[1] 2025/06/15 08:30:11.960955 [WRN] 172.17.0.1:52938 - cid:1187 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.OBJ_AOVlRsWqaejARRni': json: unknown field "domain"
[1] 2025/06/15 08:30:12.061226 [WRN] 172.17.0.1:52954 - cid:1193 - Invalid JetStream request '$G > $JS.API.STREAM.CREATE.TEST_STREAM': json: unknown field "domain"
```

The stream domain is embedded in the subject, and should not be present in the JSON payload. WIth this PR the warnings disappear.