### PR TITLE
Fix deliver policy

### DIFF
--- a/lib/gnat/jetstream/api/consumer.ex
+++ b/lib/gnat/jetstream/api/consumer.ex
@@ -506,6 +506,19 @@ defmodule Gnat.Jetstream.API.Consumer do
       valid_name?(consumer.stream_name) == false ->
         {:error, "invalid stream_name: " <> invalid_name_message()}
 
+      consumer.deliver_policy not in [
+        :all,
+        :last,
+        :new,
+        :by_start_sequence,
+        :by_start_time,
+        :last_per_subject
+      ] ->
+        {:error, "invalid deliver policy: #{consumer.deliver_policy}"}
+
+      consumer.replay_policy not in [:instant, :original] ->
+        {:error, "invalid replay policy: #{consumer.replay_policy}"}
+
       true ->
         :ok
     end


### PR DESCRIPTION
When trying to query an existing consumer with a deliver policy of `by_start_time`, this error occurs:

```** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an already existing atom

    :erlang.binary_to_existing_atom("by_start_time")
    (gnat 1.10.0) lib/gnat/jetstream/api/consumer.ex:453: Gnat.Jetstream.API.Consumer.to_config/1
    (gnat 1.10.0) lib/gnat/jetstream/api/consumer.ex:482: Gnat.Jetstream.API.Consumer.to_info/1
    (gnat 1.10.0) lib/gnat/jetstream/api/consumer.ex:301: Gnat.Jetstream.API.Consumer.info/4
```

This PR fixes the issue by extending the consumer validation to include checks on the `deliver_policy` (and `replay_policy`). Because the atoms are now included in the compiled modules the error is resolved. 