### PR TITLE
feat: add jetstream message metadata helper

### DIFF
--- a/lib/gnat/jetstream/api/message.ex
+++ b/lib/gnat/jetstream/api/message.ex
@@ -1,0 +1,104 @@
+defmodule Gnat.Jetstream.API.Message do
+  @moduledoc false
+
+  # Based on:
+  # https://github.com/nats-io/nats.py/blob/d9f24b4beae541b7723873ba0a786ea7c0ecb3d5/nats/aio/msg.py#L182
+
+  defmodule Metadata do
+    @type t :: %__MODULE__{
+            :stream_seq => integer(),
+            :consumer_seq => integer(),
+            :num_pending => integer(),
+            :num_delivered => integer(),
+            :timestamp => DateTime.t(),
+            :stream => String.t(),
+            :consumer => String.t(),
+            :domain => String.t() | nil
+          }
+
+    defstruct [
+      :stream_seq,
+      :consumer_seq,
+      :num_pending,
+      :num_delivered,
+      :timestamp,
+      :stream,
+      :consumer,
+      :domain
+    ]
+  end
+
+  @spec metadata(message :: Gnat.age()) :: {:ok, Metadata.t()} | {:error, term()}
+  def metadata(%{reply_to: "$JS.ACK." <> ack_topic}),
+    do: decode_reply_to(String.split(ack_topic, "."))
+
+  def metadata(_), do: {:error, :no_jetstream_message}
+
+  # # Subject without domain:
+  # $JS.ACK.<stream>.<consumer>.<delivered>.<sseq>.<cseq>.<tm>.<pending>
+  defp decode_reply_to([
+         stream,
+         consumer,
+         num_delivered,
+         stream_seq,
+         consumer_seq,
+         ts,
+         num_pending
+       ]) do
+    with {ts, ""} <- Integer.parse(ts),
+         {:ok, ts} <- DateTime.from_unix(ts, :nanosecond),
+         {stream_seq, ""} <- Integer.parse(stream_seq),
+         {consumer_seq, ""} <- Integer.parse(consumer_seq),
+         {num_delivered, ""} <- Integer.parse(num_delivered),
+         {num_pending, ""} <- Integer.parse(num_pending) do
+      {:ok,
+       %Metadata{
+         stream_seq: stream_seq,
+         consumer_seq: consumer_seq,
+         num_delivered: num_delivered,
+         num_pending: num_pending,
+         timestamp: ts,
+         stream: stream,
+         consumer: consumer
+       }}
+    else
+      _ ->
+        {:error, :invalid_ack_reply_to}
+    end
+  end
+
+  # Subject with domain:
+  # $JS.ACK.<domain>.<account hash>.<stream>.<consumer>.<delivered>.<sseq>.
+  #   <cseq>.<tm>.<pending>.<a token with a random value>
+  defp decode_reply_to([
+         domain,
+         _account_hash,
+         stream,
+         consumer,
+         num_delivered,
+         stream_seq,
+         consumer_seq,
+         ts,
+         num_pending,
+         _random_value
+       ]) do
+    case decode_reply_to([
+           stream,
+           consumer,
+           num_delivered,
+           stream_seq,
+           consumer_seq,
+           ts,
+           num_pending
+         ]) do
+      {:ok, metadata} ->
+        domain = if domain == "_", do: nil, else: domain
+        {:ok, %{metadata | domain: domain}}
+
+      err = {:error, _} ->
+        err
+    end
+  end
+
+  defp decode_reply_to(_), do: {:error, :invalid_ack_reply_to}
+end

--- a/test/jetstream/message_test.exs
+++ b/test/jetstream/message_test.exs
@@ -1,0 +1,38 @@
+defmodule Gnat.Jetstream.MessageTest do
+  use ExUnit.Case, async: true
+
+  test "message metadata without domain" do
+    assert {:ok,
+            %Gnat.Jetstream.API.Message.Metadata{
+              stream_seq: 1_428_472,
+              consumer_seq: 20,
+              num_pending: 3283,
+              num_delivered: 4,
+              timestamp: ~U[2025-06-26 09:09:08.439739Z],
+              stream: "STREAM",
+              consumer: "consumer",
+              domain: nil
+            }} =
+             Gnat.Jetstream.API.Message.metadata(%{
+               reply_to: "$JS.ACK.STREAM.consumer.4.1428472.20.1750928948439739269.3283"
+             })
+  end
+
+  test "message metadata with domain" do
+    assert {:ok,
+            %Gnat.Jetstream.API.Message.Metadata{
+              stream_seq: 1_428_472,
+              consumer_seq: 20,
+              num_pending: 3283,
+              num_delivered: 4,
+              timestamp: ~U[2025-06-26 09:09:08.439739Z],
+              stream: "STREAM",
+              consumer: "consumer",
+              domain: "test"
+            }} =
+             Gnat.Jetstream.API.Message.metadata(%{
+               reply_to:
+                 "$JS.ACK.test.$G.STREAM.consumer.4.1428472.20.1750928948439739269.3283.279619330"
+             })
+  end
+end


### PR DESCRIPTION
The nats python library has a useful helper function/property `message.metadata` that decodes information in the `reply_to` address of a Jetstream message: https://github.com/nats-io/nats.py/blob/d9f24b4beae541b7723873ba0a786ea7c0ecb3d5/nats/aio/msg.py#L160

This PR adds a helper function to extract the metadata information.

API doc: https://docs.nats.io/reference/reference-protocols/nats_api_reference#acknowledging-messages