### PR TITLE
Run dialyzer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,3 +64,17 @@ jobs:
 
       - name: Run unit tests
         run: mix test --color
+
+      - name: Cache Dialyzer PLTs
+        uses: actions/cache@v4
+        with:
+          path: |
+            priv/plts/*.plt
+            priv/plts/*.plt.hash
+          key: dialyzer-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            dialyzer-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-
+
+      - name: Run Dialyzer
+        run: |
+          mix dialyzer --plt priv/plts/project.plt --plt priv/plts/core.plt --no-check

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Where 3rd-party dependencies like ExDoc output generated docs.
 /doc
 
+# Dialyzer PLT files
+priv/plts/
+
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
 

--- a/lib/gnat/jetstream/api/message.ex
+++ b/lib/gnat/jetstream/api/message.ex
@@ -28,7 +28,7 @@ defmodule Gnat.Jetstream.API.Message do
     ]
   end
 
-  @spec metadata(message :: Gnat.age()) :: {:ok, Metadata.t()} | {:error, term()}
+  @spec metadata(message :: Gnat.message()) :: {:ok, Metadata.t()} | {:error, term()}
   def metadata(%{reply_to: "$JS.ACK." <> ack_topic}),
     do: decode_reply_to(String.split(ack_topic, "."))
 

--- a/lib/gnat/jetstream/pager.ex
+++ b/lib/gnat/jetstream/pager.ex
@@ -83,9 +83,6 @@ defmodule Gnat.Jetstream.Pager do
         new_state = Enum.reduce(messages, state, fun)
         :ok = cleanup(pager)
         {:ok, new_state}
-
-      {:error, error} ->
-        {:error, error}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,11 @@ defmodule Gnat.Mixfile do
       start_permanent: Mix.env() == :prod,
       package: package(),
       propcheck: [counter_examples: "test/counter_examples"],
-      dialyzer: [ignore_warnings: ".dialyzer_ignore.exs"],
+      dialyzer: [
+        ignore_warnings: ".dialyzer_ignore.exs",
+        plt_file: {:no_warn, "priv/plts/project.plt"},
+        plt_core_path: "priv/plts/core.plt"
+      ],
       deps: deps(),
       docs: docs()
     ]


### PR DESCRIPTION
I happened to run `mix dialyzer` locally and found that I had missed a few minor type issues in recent PRs. These kinds of dialyzer errors can be tricky to debug for users of the library, so I would like to automatically check dialyzer in our CI runs. I asked an AI bot to help me generate the CI job with efficient caching of the PLT files, so I'll test out doing multiple runs in this PR.