### PR TITLE
add erlang 28 with elixir 1.18 to the build matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,9 +28,13 @@ jobs:
             elixir: "1.17"
             nats: "2.10.24"
 
+          - otp: "27"
+            elixir: "1.18"
+            nats: "2.10.24"
+
           # the main pair handles things like format checking and running dialyzer
           - main: true
-            otp: "27"
+            otp: "28"
             elixir: "1.18"
             nats: "2.10.24"
 


### PR DESCRIPTION
Run Elixir 1.18 with both OTP 27 and OTP 28 builds.