### PR TITLE
Support ephemeral consumers and auto-cleanup consumers in the PullConsumer module

### DIFF
--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -61,10 +61,14 @@ defmodule Gnat.Jetstream.PullConsumer do
 
   * `:connection_name` - Gnat connection or `Gnat.ConnectionSupervisor` name/PID.
   * `:stream_name` - name of an existing string the consumer will consume messages from.
-  * `:consumer_name` - name of an existing consumer pointing at the stream.
+  * `:consumer_name` - name of an existing consumer pointing at the stream. Either this or
+    `:consumer_definition` must be provided, but not both.
 
   You can also pass the optional ones:
 
+  * `:consumer_definition` - a 0-arity function that returns a `Gnat.Jetstream.API.Consumer` struct
+    for creating an ephemeral consumer. The consumer struct must have `durable_name: nil` to be 
+    ephemeral. Either this or `:consumer_name` must be provided, but not both.
   * `:connection_retry_timeout` - a duration in milliseconds after which the PullConsumer which
     failed to establish NATS connection retries, defaults to `1000`
   * `:connection_retries` - a number of attempts the PullConsumer will make to establish the NATS
@@ -95,6 +99,42 @@ defmodule Gnat.Jetstream.PullConsumer do
         end
 
         ...
+      end
+
+  ## Ephemeral Consumer Example
+
+  You can also create ephemeral consumers by providing a `:consumer_definition` function instead
+  of a `:consumer_name`. This is useful when you want the consumer to be automatically created
+  and cleaned up with the connection lifecycle:
+
+      defmodule MyApp.EphemeralPullConsumer do
+        use Gnat.Jetstream.PullConsumer
+
+        def start_link(arg) do
+          Jetstream.PullConsumer.start_link(__MODULE__, arg)
+        end
+
+        @impl true
+        def init(_arg) do
+          consumer_definition = fn ->
+            %Gnat.Jetstream.API.Consumer{
+              stream_name: "TEST_STREAM",
+              durable_name: nil,  # Must be nil for ephemeral consumers
+              filter_subject: "orders.*"
+            }
+          end
+
+          {:ok, nil,
+            connection_name: :gnat,
+            stream_name: "TEST_STREAM",
+            consumer_definition: consumer_definition}
+        end
+
+        @impl true
+        def handle_message(message, state) do
+          # Do some processing with the message.
+          {:ack, state}
+        end
       end
 
   ## How to supervise
@@ -202,6 +242,7 @@ defmodule Gnat.Jetstream.PullConsumer do
           {:connection_name, GenServer.server()}
           | {:stream_name, String.t()}
           | {:consumer_name, String.t()}
+          | {:consumer_definition, (() -> Gnat.Jetstream.API.Consumer.t())}
           | {:connection_retry_timeout, non_neg_integer()}
           | {:connection_retries, non_neg_integer()}
           | {:domain, String.t()}

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -7,27 +7,41 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
   @enforce_keys [
     :connection_name,
     :stream_name,
-    :consumer_name,
     :connection_retry_timeout,
     :connection_retries,
     :inbox_prefix,
     :domain
   ]
 
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ [:consumer_name, :consumer_definition]
 
   def validate!(connection_options) do
-    struct!(
-      __MODULE__,
-      Keyword.validate!(connection_options, [
-        :connection_name,
-        :stream_name,
-        :consumer_name,
-        connection_retry_timeout: @default_retry_timeout,
-        connection_retries: @default_retries,
-        inbox_prefix: nil,
-        domain: nil
-      ])
-    )
+    validated_opts = Keyword.validate!(connection_options, [
+      :connection_name,
+      :stream_name,
+      :consumer_name,
+      :consumer_definition,
+      connection_retry_timeout: @default_retry_timeout,
+      connection_retries: @default_retries,
+      inbox_prefix: nil,
+      domain: nil
+    ])
+
+    consumer_name = validated_opts[:consumer_name]
+    consumer_definition = validated_opts[:consumer_definition]
+
+    cond do
+      consumer_name && consumer_definition ->
+        raise ArgumentError, "cannot specify both :consumer_name and :consumer_definition"
+
+      !consumer_name && !consumer_definition ->
+        raise ArgumentError, "must specify either :consumer_name or :consumer_definition"
+
+      consumer_definition && !is_function(consumer_definition, 0) ->
+        raise ArgumentError, ":consumer_definition must be a 0-arity function that returns a Consumer struct"
+
+      true ->
+        struct!(__MODULE__, validated_opts)
+    end
   end
 end

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -39,18 +39,22 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
       consumer && !is_struct(consumer, Gnat.Jetstream.API.Consumer) ->
         raise ArgumentError, ":consumer must be a Consumer struct"
 
+      consumer && consumer.durable_name != nil && consumer.inactive_threshold == nil ->
+        raise ArgumentError,
+              "durable consumers specified via :consumer must have inactive_threshold set for auto-cleanup"
+
       consumer ->
-        # For ephemeral consumer case, extract stream_name from consumer struct
+        # For ephemeral/auto-cleanup consumer case, extract stream_name from consumer struct
         validated_opts = Keyword.put(validated_opts, :stream_name, consumer.stream_name)
         struct!(__MODULE__, validated_opts)
 
       stream_name && consumer_name ->
-        # For durable consumer case
+        # For traditional durable consumer case
         struct!(__MODULE__, validated_opts)
 
       true ->
         raise ArgumentError,
-              "must specify either :consumer (ephemeral) or both :stream_name and :consumer_name (durable)"
+              "must specify either :consumer (ephemeral/auto-cleanup) or both :stream_name and :consumer_name (durable)"
     end
   end
 end

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -6,42 +6,51 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
 
   @enforce_keys [
     :connection_name,
-    :stream_name,
     :connection_retry_timeout,
     :connection_retries,
     :inbox_prefix,
     :domain
   ]
 
-  defstruct @enforce_keys ++ [:consumer_name, :consumer_definition]
+  defstruct @enforce_keys ++ [:stream_name, :consumer_name, :consumer]
 
   def validate!(connection_options) do
-    validated_opts = Keyword.validate!(connection_options, [
-      :connection_name,
-      :stream_name,
-      :consumer_name,
-      :consumer_definition,
-      connection_retry_timeout: @default_retry_timeout,
-      connection_retries: @default_retries,
-      inbox_prefix: nil,
-      domain: nil
-    ])
+    validated_opts =
+      Keyword.validate!(connection_options, [
+        :connection_name,
+        :stream_name,
+        :consumer_name,
+        :consumer,
+        connection_retry_timeout: @default_retry_timeout,
+        connection_retries: @default_retries,
+        inbox_prefix: nil,
+        domain: nil
+      ])
 
+    stream_name = validated_opts[:stream_name]
     consumer_name = validated_opts[:consumer_name]
-    consumer_definition = validated_opts[:consumer_definition]
+    consumer = validated_opts[:consumer]
 
     cond do
-      consumer_name && consumer_definition ->
-        raise ArgumentError, "cannot specify both :consumer_name and :consumer_definition"
+      consumer && (stream_name || consumer_name) ->
+        raise ArgumentError,
+              "cannot specify :consumer with :stream_name or :consumer_name - use consumer struct's stream_name instead"
 
-      !consumer_name && !consumer_definition ->
-        raise ArgumentError, "must specify either :consumer_name or :consumer_definition"
+      consumer && !is_struct(consumer, Gnat.Jetstream.API.Consumer) ->
+        raise ArgumentError, ":consumer must be a Consumer struct"
 
-      consumer_definition && !is_function(consumer_definition, 0) ->
-        raise ArgumentError, ":consumer_definition must be a 0-arity function that returns a Consumer struct"
+      consumer ->
+        # For ephemeral consumer case, extract stream_name from consumer struct
+        validated_opts = Keyword.put(validated_opts, :stream_name, consumer.stream_name)
+        struct!(__MODULE__, validated_opts)
+
+      stream_name && consumer_name ->
+        # For durable consumer case
+        struct!(__MODULE__, validated_opts)
 
       true ->
-        struct!(__MODULE__, validated_opts)
+        raise ArgumentError,
+              "must specify either :consumer (ephemeral) or both :stream_name and :consumer_name (durable)"
     end
   end
 end

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -189,7 +189,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         {:error, "ephemeral consumers (durable_name: nil) cannot have inactive_threshold set"}
 
       consumer_definition.durable_name != nil && consumer_definition.inactive_threshold == nil ->
-        {:error, "durable consumers specified via :consumer must have inactive_threshold set for auto-cleanup"}
+        {:error,
+         "durable consumers specified via :consumer must have inactive_threshold set for auto-cleanup"}
 
       true ->
         {:ok, consumer_definition}

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -17,7 +17,7 @@ defmodule GnatTest do
   # configuration. See https://circleci.com/docs/faq#can-i-use-ipv6-in-my-tests
   @tag :ci_skip
   test "connect to a server over IPv6" do
-    {:ok, pid} = Gnat.start_link(%{host: '::1', tcp_opts: [:binary, :inet6]})
+    {:ok, pid} = Gnat.start_link(%{host: ~c"::1", tcp_opts: [:binary, :inet6]})
     assert Process.alive?(pid)
     :ok = Gnat.stop(pid)
   end
@@ -356,7 +356,7 @@ defmodule GnatTest do
 
   test "connection timeout" do
     start = System.monotonic_time(:millisecond)
-    connection_settings = %{host: '169.33.33.33', connection_timeout: 200}
+    connection_settings = %{host: ~c"169.33.33.33", connection_timeout: 200}
     {:stop, :timeout} = Gnat.init(connection_settings)
     assert_in_delta System.monotonic_time(:millisecond) - start, 200, 10
   end

--- a/test/pull_consumer/ephemeral_test.exs
+++ b/test/pull_consumer/ephemeral_test.exs
@@ -1,0 +1,80 @@
+defmodule Gnat.Jetstream.PullConsumer.EphemeralTest do
+  use Gnat.Jetstream.ConnCase
+
+  alias Gnat.Jetstream.API.{Consumer, Stream}
+
+  defmodule ExamplePullConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      connection_opts = [
+        connection_name: :gnat,
+        stream_name: Keyword.fetch!(opts, :stream_name),
+        consumer_definition: Keyword.fetch!(opts, :consumer_definition)
+      ]
+      state = %{test_pid: Keyword.fetch!(opts, :test_pid)}
+      {:ok, state, connection_opts}
+    end
+
+    @impl true
+    def handle_message(message, state) do
+      send state.test_pid, {:pulled, message}
+      {:ack, state}
+    end
+  end
+
+  describe "Jetstream.PullConsumer" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream_name = "TEST_STREAM_2"
+      stream_subjects = ["stream_2.*"]
+
+      stream = %Stream{name: stream_name, subjects: stream_subjects}
+      {:ok, _response} = Stream.create(:gnat, stream)
+
+      on_exit(fn ->
+        cleanup()
+      end)
+
+      %{
+        stream_name: stream_name
+      }
+    end
+
+    test "ephemeral consumer receives messages", %{
+      stream_name: stream_name
+    } do
+      consumer_fn = fn ->
+        %Consumer{stream_name: stream_name}
+      end
+
+      {:ok, _resp} = Gnat.request(:gnat, "stream_2.ohai", "whatsup")
+
+      start_supervised!(
+        {ExamplePullConsumer, stream_name: stream_name, consumer_definition: consumer_fn, test_pid: self()}
+      )
+
+      assert_receive {:pulled, message}
+      assert %{topic: "stream_2.ohai", body: "whatsup"} = message
+
+      {:ok, _resp} = Gnat.request(:gnat, "stream_2.ohai", "second")
+
+      assert_receive {:pulled, message}
+      assert %{topic: "stream_2.ohai", body: "second"} = message
+    end
+  end
+
+  defp cleanup do
+    # Manage connection on our own here, because all supervised processes will be
+    # closed by the time `on_exit` runs
+    {:ok, pid} = Gnat.start_link()
+    :ok = Stream.delete(pid, "TEST_STREAM_2")
+    Gnat.stop(pid)
+  end
+end


### PR DESCRIPTION
This PR feature should help with cases where people want to supervise a process that will consume a stream with short-lived consumers in-mind.