### PR TITLE
Allow clients to force authentication without server auth_required

### DIFF
--- a/lib/gnat/jetstream/api/message.ex
+++ b/lib/gnat/jetstream/api/message.ex
@@ -1,5 +1,8 @@
 defmodule Gnat.Jetstream.API.Message do
-  @moduledoc false
+  @moduledoc """
+  This module provides a way to parse the `reply_to` received by a PullConsumer
+  and get some useful information about the state of the consumer.
+  """
 
   # Based on:
   # https://github.com/nats-io/nats.py/blob/d9f24b4beae541b7723873ba0a786ea7c0ecb3d5/nats/aio/msg.py#L182

--- a/test/gnat/handshake_test.exs
+++ b/test/gnat/handshake_test.exs
@@ -1,0 +1,87 @@
+defmodule Gnat.HandshakeTest do
+  use ExUnit.Case, async: true
+  alias Gnat.Handshake
+
+  describe "negotiate_settings/2" do
+    test "respects server auth_required setting" do
+      server_settings = %{auth_required: true}
+      user_settings = %{username: "test", password: "secret"}
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert result[:user] == "test"
+      assert result[:pass] == "secret"
+    end
+
+    test "allows client to force auth when server doesn't require it" do
+      server_settings = %{}
+      user_settings = %{username: "test", password: "secret", auth_required: true}
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert result[:user] == "test"
+      assert result[:pass] == "secret"
+    end
+
+    test "allows client to force auth with token when server doesn't require it" do
+      server_settings = %{}
+      user_settings = %{token: "my-secret-token", auth_required: true}
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert result[:auth_token] == "my-secret-token"
+    end
+
+    test "doesn't send auth when neither server nor client requires it" do
+      server_settings = %{}
+      user_settings = %{username: "test", password: "secret"}
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      refute Map.has_key?(result, :user)
+      refute Map.has_key?(result, :pass)
+      refute Map.has_key?(result, :auth_token)
+    end
+
+    test "client auth_required setting takes precedence over server setting being false" do
+      server_settings = %{auth_required: false}
+      user_settings = %{username: "test", password: "secret", auth_required: true}
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert result[:user] == "test"
+      assert result[:pass] == "secret"
+    end
+
+    test "works with nkey authentication when client forces auth" do
+      nonce = "test-nonce-value"
+      server_settings = %{nonce: nonce}
+      user_settings = %{
+        nkey_seed: "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4",
+        auth_required: true
+      }
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert Map.has_key?(result, :sig)
+      assert Map.has_key?(result, :nkey)
+      assert result[:protocol] == 1
+    end
+
+    test "works with JWT+nkey authentication when client forces auth" do
+      nonce = "test-nonce-value"
+      server_settings = %{nonce: nonce}
+      user_settings = %{
+        nkey_seed: "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4",
+        jwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJPUkhQUERHQ1FHRVdPSkZOUVIzM0tFSzVYT0lHSElNNlFOTVFOUUVIVlJLWVpGUkQ3NFNBIiwiaWF0IjoxNjM4MzMzMjI4LCJpc3MiOiJBQlpMM1pSRkdYNTQzRkU1SkdDMkVFQkJRVVhSREQ1TFdWN1dYSEdCSEdOUko2Nks0VUNJUEFHMyIsIm5hbWUiOiJ0ZXN0LXVzZXIiLCJzdWIiOiJVQzJGRllPUTVQWUEyQU5aREFCV1daSEhNRE5JVVdLQ0VITldNSUNCNlo2U1hLNEdOVUFZUUdCUCIsIm5hdHMiOnsicHViIjp7fSwic3ViIjp7fSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0.test-signature",
+        auth_required: true
+      }
+
+      result = Handshake.negotiate_settings(server_settings, user_settings)
+
+      assert Map.has_key?(result, :sig)
+      assert Map.has_key?(result, :jwt)
+      assert result[:protocol] == 1
+    end
+  end
+end

--- a/test/gnat/handshake_test.exs
+++ b/test/gnat/handshake_test.exs
@@ -56,6 +56,7 @@ defmodule Gnat.HandshakeTest do
     test "works with nkey authentication when client forces auth" do
       nonce = "test-nonce-value"
       server_settings = %{nonce: nonce}
+
       user_settings = %{
         nkey_seed: "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4",
         auth_required: true
@@ -71,9 +72,11 @@ defmodule Gnat.HandshakeTest do
     test "works with JWT+nkey authentication when client forces auth" do
       nonce = "test-nonce-value"
       server_settings = %{nonce: nonce}
+
       user_settings = %{
         nkey_seed: "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4",
-        jwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJPUkhQUERHQ1FHRVdPSkZOUVIzM0tFSzVYT0lHSElNNlFOTVFOUUVIVlJLWVpGUkQ3NFNBIiwiaWF0IjoxNjM4MzMzMjI4LCJpc3MiOiJBQlpMM1pSRkdYNTQzRkU1SkdDMkVFQkJRVVhSREQ1TFdWN1dYSEdCSEdOUko2Nks0VUNJUEFHMyIsIm5hbWUiOiJ0ZXN0LXVzZXIiLCJzdWIiOiJVQzJGRllPUTVQWUEyQU5aREFCV1daSEhNRE5JVVdLQ0VITldNSUNCNlo2U1hLNEdOVUFZUUdCUCIsIm5hdHMiOnsicHViIjp7fSwic3ViIjp7fSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0.test-signature",
+        jwt:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJPUkhQUERHQ1FHRVdPSkZOUVIzM0tFSzVYT0lHSElNNlFOTVFOUUVIVlJLWVpGUkQ3NFNBIiwiaWF0IjoxNjM4MzMzMjI4LCJpc3MiOiJBQlpMM1pSRkdYNTQzRkU1SkdDMkVFQkJRVVhSREQ1TFdWN1dYSEdCSEdOUko2Nks0VUNJUEFHMyIsIm5hbWUiOiJ0ZXN0LXVzZXIiLCJzdWIiOiJVQzJGRllPUTVQWUEyQU5aREFCV1daSEhNRE5JVVdLQ0VITldNSUNCNlo2U1hLNEdOVUFZUUdCUCIsIm5hdHMiOnsicHViIjp7fSwic3ViIjp7fSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0.test-signature",
         auth_required: true
       }
 


### PR DESCRIPTION
Resolves #132

This change allows NATS clients to send authentication credentials even when the server doesn't explicitly request them via auth_required: true. This is useful for servers that require auth but don't advertise it, such as multi-account configurations.

Changes:
- Modified negotiate_settings/2 to consider user_settings[:auth_required]
- Updated all negotiate_auth functions to accept auth_required parameter
- Added comprehensive tests for the new functionality

Based on original work by @lubien in PR #135:
https://github.com/nats-io/nats.ex/pull/135

🤖 Generated with [Claude Code](https://claude.ai/code)