### PR TITLE
specify minimal CI permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 1 */1 *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Elixir ${{ matrix.pair.elixir }} / OTP ${{ matrix.pair.otp }} / NATS ${{ matrix.pair.nats }}


### PR DESCRIPTION
Based on https://github.com/nats-io/nats.ex/security/code-scanning/2