### PR TITLE
feat: fetch the keys without the contents

### DIFF
--- a/lib/gnat/jetstream/pager.ex
+++ b/lib/gnat/jetstream/pager.ex
@@ -18,7 +18,8 @@ defmodule Gnat.Jetstream.Pager do
       deliver_policy: :all,
       description: "ephemeral consumer",
       replay_policy: :instant,
-      inactive_threshold: 30_000_000_000
+      inactive_threshold: 30_000_000_000,
+      headers_only: Keyword.get(opts, :headers_only)
     }
 
     consumer = apply_opts_to_consumer(consumer, opts)


### PR DESCRIPTION
There were some instances where I only wanted to fetch the keys. The contents were quite large in my KV and there were thousands of entries. This made it so I could just get a list of the keys without all the bytes over the wire.

For my KV, it was only 5500 keys and about 43Mib and `KV.contents` was taking 200+ seconds. Exposing batching reduced that down to 7-8 seconds.