### PR TITLE
Implement AllowMsgTTL and SubjectDeleteMarkerTTL

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,10 @@ jobs:
             elixir: "1.18"
             nats: "2.10.24"
 
+          - otp: "28"
+            elixir: "1.18"
+            nats: "2.11.11"
+
           # the main pair handles things like format checking and running dialyzer
           - main: true
             otp: "28"
@@ -74,6 +78,10 @@ jobs:
 
       - name: Run unit tests
         run: mix test --color
+
+      - name: Run NATS 2.11 specific tests
+        if: ${{ matrix.pair.nats == '2.11.11' }}
+        run: mix test --only message_ttl
 
       - name: Cache Dialyzer PLTs
         if: matrix.pair.main

--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -13,6 +13,7 @@ defmodule Gnat.Jetstream.API.KV do
   @type bucket_options ::
           {:history, non_neg_integer()}
           | {:ttl, non_neg_integer()}
+          | {:limit_marker_ttl, non_neg_integer()}
           | {:max_bucket_size, non_neg_integer()}
           | {:max_value_size, non_neg_integer()}
           | {:description, binary()}
@@ -25,6 +26,7 @@ defmodule Gnat.Jetstream.API.KV do
 
   * `:history` - How many historic values to keep per key (defaults to 1, max of 64)
   * `:ttl` - How long to keep values for (in nanoseconds)
+  * `:limit_marker_ttl` - How long the bucket keeps markers when keys are removed by the TTL setting.
   * `:max_bucket_size` - The max number of bytes the bucket can hold
   * `:max_value_size` - The max number of bytes a value may be
   * `:description` - A description for the bucket
@@ -59,7 +61,8 @@ defmodule Gnat.Jetstream.API.KV do
       num_replicas: Keyword.get(params, :replicas, 1),
       storage: Keyword.get(params, :storage, :file),
       placement: Keyword.get(params, :placement),
-      duplicate_window: adjust_duplicate_window(Keyword.get(params, :ttl, 0))
+      duplicate_window: adjust_duplicate_window(Keyword.get(params, :ttl, 0)),
+      subject_delete_marker_ttl: Keyword.get(params, :limit_marker_ttl, 0)
     }
 
     Stream.create(conn, stream)

--- a/lib/gnat/jetstream/api/stream.ex
+++ b/lib/gnat/jetstream/api/stream.ex
@@ -12,6 +12,7 @@ defmodule Gnat.Jetstream.API.Stream do
   Stream struct fields explanation:
 
   * `:allow_direct` - Allow higher performance, direct access to get individual messages. E.g. KeyValue
+  * `:allow_msg_ttl` - Allow header initiated per-message TTLs.
   * `:allow_rollup_hdrs` - allows the use of the Nats-Rollup header to replace all contents of a stream,
     or subject in a stream, with a single new message.
   * `:deny_delete` - restricts the ability to delete messages from a stream via the API. Cannot be changed
@@ -61,6 +62,8 @@ defmodule Gnat.Jetstream.API.Stream do
   * `:compression` - If file-based and a compression algorithm is specified, the stream data will be compressed on disk.
     Valid options are "none" for no compression or "s2" for Snappy compression.
   * `:subjects` - a list of subjects to consume, supports wildcards.
+  * `:subject_delete_marker_ttl` - Enables and sets a duration expressed in nanoseconds. for adding server markers for
+    delete, purge and max age limits.
   * `:template_owner` - when the Stream is managed by a Stream Template this identifies the template that
     manages the Stream.
   """
@@ -80,6 +83,7 @@ defmodule Gnat.Jetstream.API.Stream do
     :subjects,
     :template_owner,
     allow_direct: false,
+    allow_msg_ttl: false,
     allow_rollup_hdrs: false,
     deny_delete: false,
     deny_purge: false,
@@ -96,6 +100,7 @@ defmodule Gnat.Jetstream.API.Stream do
     retention: :limits,
     sealed: false,
     storage: :file,
+    subject_delete_marker_ttl: 0,
     discard_new_per_subject: false,
     compression: "none"
   ]
@@ -109,6 +114,7 @@ defmodule Gnat.Jetstream.API.Stream do
 
   @type t :: %__MODULE__{
           allow_direct: boolean(),
+          allow_msg_ttl: boolean(),
           allow_rollup_hdrs: boolean(),
           deny_delete: boolean(),
           deny_purge: boolean(),
@@ -133,6 +139,7 @@ defmodule Gnat.Jetstream.API.Stream do
           sources: nil | list(source()),
           storage: :file | :memory,
           subjects: nil | list(binary()),
+          subject_delete_marker_ttl: nanoseconds(),
           template_owner: nil | binary(),
           discard_new_per_subject: boolean(),
           compression: binary()
@@ -510,12 +517,14 @@ defmodule Gnat.Jetstream.API.Stream do
     }
     # Check for fields added in NATS versions higher than 2.2.0
     |> put_if_exist(:allow_direct, stream, "allow_direct")
+    |> put_if_exist(:allow_msg_ttl, stream, "allow_msg_ttl")
     |> put_if_exist(:allow_rollup_hdrs, stream, "allow_rollup_hdrs")
     |> put_if_exist(:deny_delete, stream, "deny_delete")
     |> put_if_exist(:deny_purge, stream, "deny_purge")
     |> put_if_exist(:discard_new_per_subject, stream, "discard_new_per_subject")
     |> put_if_exist(:mirror_direct, stream, "mirror_direct")
     |> put_if_exist(:sealed, stream, "sealed")
+    |> put_if_exist(:subject_delete_marker_ttl, stream, "subject_delete_marker_ttl")
     |> put_if_exist(:compression, stream, "compression")
   end
 

--- a/test/jetstream/api/kv_test.exs
+++ b/test/jetstream/api/kv_test.exs
@@ -34,6 +34,16 @@ defmodule Gnat.Jetstream.API.KVTest do
 
       assert :ok = KV.delete_bucket(:gnat, "OTHER_TTL_TEST")
     end
+
+    @tag :message_ttl
+    test "creates a bucket with limit_marker_ttl" do
+      assert {:ok, %{config: config}} =
+               KV.create_bucket(:gnat, "LIMIT_MARKER_TTL_TEST", limit_marker_ttl: 1_000_000_000)
+
+      assert config.subject_delete_marker_ttl == 1_000_000_000
+
+      assert :ok = KV.delete_bucket(:gnat, "LIMIT_MARKER_TTL_TEST")
+    end
   end
 
   test "create_key/4 creates a key" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.configure(exclude: [:pending, :property, :multi_server])
+ExUnit.configure(exclude: [:pending, :property, :multi_server, :message_ttl])
 
 ExUnit.start()
 


### PR DESCRIPTION
This commit provides two options supported by the newer versions of NATS:

- AllowMsgTTL
- SubjectDeleteMarkerTTL

Partially fixes - https://github.com/nats-io/nats.ex/issues/208