### PR TITLE
Document the Pager module and add support for from_datetime

### DIFF
--- a/lib/gnat/jetstream/pager.ex
+++ b/lib/gnat/jetstream/pager.ex
@@ -1,12 +1,32 @@
 defmodule Gnat.Jetstream.Pager do
-  @moduledoc false
+  @moduledoc """
+  Page through all the messages in a stream
+
+  This module provides a synchronous API to inspect the messages in a stream.
+  You can use the reduce module to write a simple function that works like `Enum.reduce` across each message individually.
+  If you want to handle messages in batches, you can use the `init` + `page` functions to accomplish that.
+  """
 
   alias Gnat.Jetstream
   alias Gnat.Jetstream.API.{Consumer, Util}
 
   @opaque pager :: map()
   @type message :: Gnat.message()
+  @type opts :: list(opt())
 
+  @typedoc """
+  Options you can pass to the pager
+
+  * `batch` controls the maximum number of messages we'll pull in each page/batch (default 10)
+  * `domain` You can specify a jetstream domain if needed
+  * `from_datetime` Only page through messages recorded on or after this datetime
+  * `from_seq` Only page through messages with a sequence number equal or above this option
+  * `headers_only` You can pass `true` to this if you only want to see the headers from each message. Can be useful to get metadata without having to receieve large body payloads.
+
+  """
+  @type opt :: {:batch, non_neg_integer()} | {:domain, String.t()} | {:from_datetime, DateTime.t()} | {:from_seq, non_neg_integer} | {:headers_only, boolean()}
+
+  @spec init(Gnat.t(), String.t(), opts()) :: {:ok, pager()} | {:error, term()}
   def init(conn, stream_name, opts) do
     domain = Keyword.get(opts, :domainl)
 
@@ -55,6 +75,20 @@ defmodule Gnat.Jetstream.Pager do
     end
   end
 
+  @doc """
+  Similar to Enum.reduce but you can iterate through all messages in a stream
+
+  ```
+  # Assume we have a stream with messages like "1", "2", ... "10"
+  Gnat.Jetstream.Pager.reduce(:gnat, "NUMBERS_STREAM", [batch_size: 5], 0, fn(message, total) ->
+    num = String.to_integer(message.body)
+    total + num
+  end)
+
+  # => {:ok, 55}
+  ```
+  """
+  @spec reduce(Gnat.t(), String.t(), opts(), Enum.acc(), (Gnat.message(), Enum.acc() -> Enum.acc())) :: {:ok, Enum.acc()} | {:error, term()}
   def reduce(conn, stream_name, opts, initial_state, fun) do
     with {:ok, pager} <- init(conn, stream_name, opts) do
       page_through(pager, initial_state, fun)
@@ -109,12 +143,17 @@ defmodule Gnat.Jetstream.Pager do
 
   ## Helpers for accepting user options
   defp apply_opts_to_consumer(consumer = %Consumer{}, opts) do
-    case Keyword.get(opts, :from_seq) do
-      nil ->
+    from = {Keyword.get(opts, :from_seq), Keyword.get(opts, :from_datetime)}
+
+    case from do
+      {nil, nil} ->
         consumer
 
-      seq when is_integer(seq) ->
+      {seq, _} when is_integer(seq) ->
         %Consumer{consumer | deliver_policy: :by_start_sequence, opt_start_seq: seq}
+
+      {_, %DateTime{} = dt} ->
+        %Consumer{consumer | deliver_policy: :by_start_time, opt_start_time: dt}
     end
   end
 end

--- a/lib/gnat/jetstream/pager.ex
+++ b/lib/gnat/jetstream/pager.ex
@@ -24,7 +24,12 @@ defmodule Gnat.Jetstream.Pager do
   * `headers_only` You can pass `true` to this if you only want to see the headers from each message. Can be useful to get metadata without having to receieve large body payloads.
 
   """
-  @type opt :: {:batch, non_neg_integer()} | {:domain, String.t()} | {:from_datetime, DateTime.t()} | {:from_seq, non_neg_integer} | {:headers_only, boolean()}
+  @type opt ::
+          {:batch, non_neg_integer()}
+          | {:domain, String.t()}
+          | {:from_datetime, DateTime.t()}
+          | {:from_seq, non_neg_integer}
+          | {:headers_only, boolean()}
 
   @spec init(Gnat.t(), String.t(), opts()) :: {:ok, pager()} | {:error, term()}
   def init(conn, stream_name, opts) do
@@ -88,7 +93,13 @@ defmodule Gnat.Jetstream.Pager do
   # => {:ok, 55}
   ```
   """
-  @spec reduce(Gnat.t(), String.t(), opts(), Enum.acc(), (Gnat.message(), Enum.acc() -> Enum.acc())) :: {:ok, Enum.acc()} | {:error, term()}
+  @spec reduce(
+          Gnat.t(),
+          String.t(),
+          opts(),
+          Enum.acc(),
+          (Gnat.message(), Enum.acc() -> Enum.acc())
+        ) :: {:ok, Enum.acc()} | {:error, term()}
   def reduce(conn, stream_name, opts, initial_state, fun) do
     with {:ok, pager} <- init(conn, stream_name, opts) do
       page_through(pager, initial_state, fun)


### PR DESCRIPTION
We've had the `Pager` module in-use internally for a while and we've even pointed people to it in issues (see https://github.com/nats-io/nats.ex/issues/195)

This is a very useful helper so I thought it was time to document it and I also wanted to add support for the `from_datetime` option so people can easily page a portion of a stream without knowing the exact sequence numbers.