### PR TITLE
Use flow_control for Object.get

### DIFF
--- a/lib/gnat/jetstream/api/object.ex
+++ b/lib/gnat/jetstream/api/object.ex
@@ -284,24 +284,37 @@ defmodule Gnat.Jetstream.API.Object do
         ack_policy: :none,
         max_ack_pending: nil,
         replay_policy: :instant,
-        max_deliver: 1
+        max_deliver: 1,
+        flow_control: true,
+        idle_heartbeat: 5_000_000_000
       })
 
-    :ok = receive_chunks(sub, meta.chunks, chunk_fun)
+    :ok = receive_chunks(conn, sub, meta.chunks, chunk_fun)
 
     :ok = Gnat.unsub(conn, sub)
     :ok = Consumer.delete(conn, stream, consumer.name)
   end
 
-  defp receive_chunks(_sub, 0, _chunk_fun) do
+  defp receive_chunks(_conn, _sub, 0, _chunk_fun) do
     :ok
   end
 
-  defp receive_chunks(sub, remaining, chunk_fun) do
+  defp receive_chunks(conn, sub, remaining, chunk_fun) do
     receive do
+      # Flow control message with reply - respond to it
+      {:msg, %{sid: ^sub, status: "100", description: "FlowControl Request", reply_to: reply}}
+      when not is_nil(reply) ->
+        Gnat.pub(conn, reply, "")
+        receive_chunks(conn, sub, remaining, chunk_fun)
+
+      # Flow control or heartbeat message without reply - get next message
+      {:msg, %{sid: ^sub, body: "", status: "100"}} ->
+        receive_chunks(conn, sub, remaining, chunk_fun)
+
+      # Regular data message
       {:msg, %{sid: ^sub, body: body}} ->
         chunk_fun.(body)
-        receive_chunks(sub, remaining - 1, chunk_fun)
+        receive_chunks(conn, sub, remaining - 1, chunk_fun)
     after
       10_000 ->
         {:error, :timeout_waiting_for_messages}

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nats-io/nats.ex"
-  @version "1.12.1"
+  @version "1.13.0"
 
   def project do
     [

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -166,8 +166,8 @@ defmodule Gnat.Jetstream.API.ObjectTest do
     bucket = nuid()
     assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, bucket)
     assert {:ok, meta} = put_filepath(path, bucket, "big")
-    assert meta.chunks == 8
-    assert meta.size == 8 * 128 * 1024
+    assert meta.chunks == 800
+    assert meta.size == 800 * 128 * 1024
     assert "SHA-256=" <> encoded = meta.digest
     assert Base.url_decode64!(encoded) == sha
 
@@ -184,6 +184,27 @@ defmodule Gnat.Jetstream.API.ObjectTest do
 
     assert :ok = Object.delete(:gnat, bucket, "big")
     assert stream_byte_size(bucket) < 1024
+    :ok = Object.delete_bucket(:gnat, bucket)
+  end
+
+  @tag :tmp_dir
+  test "control messages don't affect chunk count", %{tmp_dir: tmp_dir} do
+    assert {:ok, path, _sha} = generate_big_file(tmp_dir)
+    bucket = nuid()
+    assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, bucket)
+    assert {:ok, meta} = put_filepath(path, bucket, "test_chunks")
+
+    Process.put(:chunk_count, 0)
+
+    :ok =
+      Object.get(:gnat, bucket, "test_chunks", fn _chunk ->
+        Process.put(:chunk_count, Process.get(:chunk_count) + 1)
+      end)
+
+    chunk_count = Process.get(:chunk_count)
+
+    assert chunk_count == meta.chunks
+
     :ok = Object.delete_bucket(:gnat, bucket)
   end
 
@@ -214,7 +235,7 @@ defmodule Gnat.Jetstream.API.ObjectTest do
     end
   end
 
-  # create a random 1MB binary file
+  # create a random 100MB binary file
   # re-use it on subsequent test runs if it already exists
   defp generate_big_file(tmp_dir) do
     filepath = Path.join(tmp_dir, "big_file.bin")
@@ -222,7 +243,7 @@ defmodule Gnat.Jetstream.API.ObjectTest do
     {:ok, fh} = File.open(filepath, [:write])
 
     sha =
-      Enum.reduce(1..8, sha, fn _, digest ->
+      Enum.reduce(1..800, sha, fn _, digest ->
         rand_chunk = :crypto.strong_rand_bytes(128) |> String.duplicate(1024)
         :ok = IO.binwrite(fh, rand_chunk)
         :crypto.hash_update(digest, rand_chunk)


### PR DESCRIPTION
We were experiencing issues with "Slow Consumer" messages when using Object.get with a combination of large files (~100MB) and high-latency chunk functions like file and network IO. The nats server was cutting off the consumer before it could process the whole file.

Digging into nats.go I discovered that they use the flow_control setting for their Object.get consumer. This requires sending ack replies to FlowControl messages from the server. The server uses this to control how much data it sends to not overwhelm the consumer.

This PR solves our problem internally and will bring the library more in line with the nats.go implementation.

I looked into using the Pager module but it doesn't fit well because we need to pass the connection to each call in case we need to reply to a FlowControl message. That didn't fit well with the current implementation of Pager.reduce/5