### PR TITLE
introduce on_connected callback

### DIFF
--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -261,6 +261,42 @@ defmodule Gnat.Jetstream.PullConsumer do
               {ack_action, new_state}
             when ack_action: :ack | :nack | :term | :noreply, new_state: term()
 
+  @doc """
+  Invoked after the consumer has been created or verified on the NATS server.
+
+  This callback is called during connection (and reconnection) after the JetStream
+  consumer has been successfully created or confirmed to exist. It receives the full
+  consumer info map returned by the server, which includes fields like `num_pending`
+  (the number of messages waiting to be delivered).
+
+  This is useful for detecting the initial state of the consumer. For example, if
+  `num_pending` is `0`, you know there are no existing messages to replay and can
+  mark the consumer as caught up immediately.
+
+  Returning `{:ok, state}` allows you to update the consumer's state based on the
+  consumer info.
+
+  This callback is optional. If not implemented, the state is passed through unchanged.
+
+  ## Example
+
+      @impl true
+      def handle_connected(consumer_info, state) do
+        if consumer_info.num_pending == 0 do
+          {:ok, mark_as_loaded(state)}
+        else
+          {:ok, state}
+        end
+      end
+
+  """
+  @callback handle_connected(
+              consumer_info :: Gnat.Jetstream.API.Consumer.info(),
+              state :: term()
+            ) :: {:ok, new_state :: term()}
+
+  @optional_callbacks [handle_connected: 2]
+
   @typedoc """
   The pull consumer reference.
   """

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -71,7 +71,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
 
     with {:ok, conn} <- connection_pid(connection_name),
          monitor_ref = Process.monitor(conn),
-         {:ok, final_consumer_name} <-
+         {:ok, consumer_info} <-
            ensure_consumer_exists(
              conn,
              stream_name,
@@ -79,12 +79,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
              consumer,
              domain
            ),
+         final_consumer_name = consumer_info.name,
+         state = maybe_handle_connected(module, consumer_info, gen_state.state),
          {:ok, sid} <- Gnat.sub(conn, self(), listening_topic),
          gen_state = %{
            gen_state
            | subscription_id: sid,
              connection_monitor_ref: monitor_ref,
-             consumer_name: final_consumer_name
+             consumer_name: final_consumer_name,
+             state: state
          },
          :ok <- next_message(conn, stream_name, final_consumer_name, domain, listening_topic),
          gen_state = %{gen_state | current_retry: 0} do
@@ -160,8 +163,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
   defp ensure_consumer_exists(gnat, stream_name, consumer_name, nil, domain) do
     # Durable consumer case - just check it exists
     try do
-      case check_consumer_exists(gnat, stream_name, consumer_name, domain) do
-        :ok -> {:ok, consumer_name}
+      case Gnat.Jetstream.API.Consumer.info(gnat, stream_name, consumer_name, domain) do
+        {:ok, consumer_info} -> {:ok, consumer_info}
         {:error, reason} -> {:error, reason}
       end
     catch
@@ -175,7 +178,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     try do
       with {:ok, consumer_definition} <- validate_consumer_for_creation(consumer_struct),
            {:ok, consumer_info} <- Gnat.Jetstream.API.Consumer.create(gnat, consumer_definition) do
-        {:ok, consumer_info.name}
+        {:ok, consumer_info}
       end
     catch
       :exit, reason -> {:error, {:process_exit, reason}}
@@ -197,13 +200,12 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
-  defp check_consumer_exists(gnat, stream_name, consumer_name, domain) do
-    case Gnat.Jetstream.API.Consumer.info(gnat, stream_name, consumer_name, domain) do
-      {:ok, _consumer} ->
-        :ok
-
-      {:error, message} ->
-        {:error, message}
+  defp maybe_handle_connected(module, consumer_info, state) do
+    if function_exported?(module, :handle_connected, 2) do
+      {:ok, state} = module.handle_connected(consumer_info, state)
+      state
+    else
+      state
     end
   end
 

--- a/test/pull_consumer/ephemeral_test.exs
+++ b/test/pull_consumer/ephemeral_test.exs
@@ -24,6 +24,12 @@ defmodule Gnat.Jetstream.PullConsumer.EphemeralTest do
     end
 
     @impl true
+    def handle_connected(consumer_info, state) do
+      send(state.test_pid, {:connected, consumer_info})
+      {:ok, state}
+    end
+
+    @impl true
     def handle_message(message, state) do
       send(state.test_pid, {:pulled, message})
       {:ack, state}
@@ -57,6 +63,9 @@ defmodule Gnat.Jetstream.PullConsumer.EphemeralTest do
       {:ok, _resp} = Gnat.request(:gnat, "stream_2.ohai", "whatsup")
 
       start_supervised!({ExamplePullConsumer, consumer: consumer, test_pid: self()})
+
+      assert_receive {:connected, consumer_info}
+      assert consumer_info.num_pending == 1
 
       assert_receive {:pulled, message}
       assert %{topic: "stream_2.ohai", body: "whatsup"} = message


### PR DESCRIPTION
I'm working on a use-case at work where I want to subscribe to a KV bucket and I wanted to have the ability to detect when the data has been initially loaded and we're now just waiting on future updates. In this case each running instance has it's own ephemeral consumer for a relatively small stream and it's really useful to know how many pending messages are outstanding at the time that my PullConsumer starts up.

I can also check on progress by checking the metadata on the subsequent `handle_message` function calls, but if the KV bucket is empty at startup, I need to know that there are 0 pending messages in order to mark that my consumer has "caught up" and is ready to be used.