### PR TITLE
1.14.0 Release Candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ erl_crash.dump
 
 # ASDF file to for specifying which erlang/elixir version to use for local development
 .tool-versions
+
+# Ignore Cluster details
+scripts/cluster/data
+scripts/cluster/logs
+scripts/cluster/pids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 1.14
 
 * Add `PullConsumer.handle_connected/2` optional callback to get consumer info
-* Add `PullConsumer.hanle_status/2` optional callback to observe status messages
+* Add `PullConsumer.handle_status/2` optional callback to observe status messages
 * Added support for `batch_size` option in PullConsumer options to pull messages
-  and acknolwedge them in batches.
+  and acknowledge them in batches.
 * Add `Gnat.Jetstream.API.KV.Entry` with `from_message/2` for parsing a raw
   NATS message from a KV bucket's underlying stream into a structured entry
   (operation, key, value, revision, created, delta). Intended to be shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.14
+
+* Add `Gnat.Jetstream.API.KV.Entry` with `from_message/2` for parsing a raw
+  NATS message from a KV bucket's underlying stream into a structured entry
+  (operation, key, value, revision, created, delta). Intended to be shared
+  between the built-in `KV.Watcher` and user-supplied `PullConsumer`
+  implementations (e.g. caches that need to detect when they are caught up
+  with the stream). Returns `:ignore` for messages that are not KV records.
+* `KV.Watcher` now uses `KV.Entry` internally; its public callback API is
+  unchanged. The push consumer it creates now enables server-driven flow
+  control and a 5s idle heartbeat (matching nats.go's ordered-consumer
+  defaults), so slow handlers apply backpressure instead of being dropped
+  as slow consumers.
+* **Behavior change (bugfix):** `PullConsumer` no longer forwards JetStream
+  informational status messages (e.g. `100` idle heartbeat, `409` leadership
+  change) to `c:handle_message/2`. These are not stream records and cannot
+  be acked. In single-message mode the consumer now drops them and re-issues
+  a pull request.
+* Add an optional `c:handle_status/2` callback to `Gnat.Jetstream.PullConsumer`
+  for users who want to observe status messages (e.g. log on `409`).
+
 ## 1.11
 
 * Allow clients to force authentication without server auth_required by @mmmries in #205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.14
 
+* Add `PullConsumer.handle_connected/2` optional callback to get consumer info
+* Add `PullConsumer.hanle_status/2` optional callback to observe status messages
+* Added support for `batch_size` option in PullConsumer options to pull messages
+  and acknolwedge them in batches.
 * Add `Gnat.Jetstream.API.KV.Entry` with `from_message/2` for parsing a raw
   NATS message from a KV bucket's underlying stream into a structured entry
   (operation, key, value, revision, created, delta). Intended to be shared

--- a/bench/kv_consume.exs
+++ b/bench/kv_consume.exs
@@ -29,7 +29,7 @@ defmodule BenchBatchPullConsumer do
   use Gnat.Jetstream.PullConsumer
 
   def start(args) do
-    Gnat.Jetstream.PullConsumer.start(__MODULE__, args, name: __MODULE__)
+    Gnat.Jetstream.PullConsumer.start(__MODULE__, args)
   end
 
   @impl true

--- a/bench/kv_consume.exs
+++ b/bench/kv_consume.exs
@@ -1,0 +1,284 @@
+# bench/kv_consume.exs
+#
+# Compares three approaches for consuming all messages from a KV bucket into ETS:
+#
+#   1. Pager (batch 500, ack_policy: :all) — fetch a page, process, ack last, repeat
+#   2. Pull + ack_next pipeline (initial batch 500, ack_policy: :explicit) — prime the
+#      pipeline with a batch request, then ack_next each message to keep flow continuous
+#   3. PullConsumer with batch_size (ack_policy: :all) — the new batch mode using the
+#      actual PullConsumer behaviour, batches messages and acks only the last per batch
+#
+# Prerequisites:
+#   - NATS server with JetStream enabled: nats-server -js
+#   - Run with: mix run bench/kv_consume.exs
+#
+# Optional env vars:
+#   - BENCH_COUNT: number of messages (default 100000)
+#   - BENCH_BATCH: batch size (default 500)
+#   - BENCH_TIME: seconds per scenario (default 60)
+
+Logger.configure(level: :warning)
+
+require Logger
+Logger.configure(level: :warning)
+
+alias Gnat.Jetstream.API.{Consumer, KV}
+alias Gnat.Jetstream.API.Util
+
+defmodule BenchBatchPullConsumer do
+  use Gnat.Jetstream.PullConsumer
+
+  def start(args) do
+    Gnat.Jetstream.PullConsumer.start(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(%{tab: tab, notify: pid, expected: expected, batch_size: batch_size}) do
+    consumer = %Consumer{
+      stream_name: "KV_BENCH_KV",
+      ack_policy: :all,
+      ack_wait: 30_000_000_000,
+      deliver_policy: :all,
+      replay_policy: :instant
+    }
+
+    {:ok, %{tab: tab, notify: pid, expected: expected, received: 0},
+     connection_name: :gnat_bench, consumer: consumer, batch_size: batch_size}
+  end
+
+  @impl true
+  def handle_message(message, state) do
+    :ets.insert(state.tab, {message.topic, message.body})
+    received = state.received + 1
+
+    if received >= state.expected do
+      send(state.notify, {:done, received})
+    end
+
+    {:ack, %{state | received: received}}
+  end
+end
+
+defmodule KVConsumeBench do
+  @bucket "BENCH_KV"
+  @stream "KV_BENCH_KV"
+  @value_size 64
+
+  def setup(conn, count) do
+    # Clean up previous state
+    KV.delete_bucket(conn, @bucket)
+    :timer.sleep(500)
+
+    {:ok, _} = KV.create_bucket(conn, @bucket, history: 1)
+
+    IO.puts("Populating #{count} messages (#{@value_size} byte values)...")
+    start = System.monotonic_time(:millisecond)
+
+    Enum.each(1..count, fn i ->
+      key = "key.#{String.pad_leading(Integer.to_string(i), 7, "0")}"
+      value = :crypto.strong_rand_bytes(@value_size) |> Base.encode64()
+      :ok = KV.put_value(conn, @bucket, key, value)
+
+      if rem(i, 10_000) == 0 do
+        elapsed = System.monotonic_time(:millisecond) - start
+        rate = round(i / elapsed * 1000)
+        IO.puts("  #{i}/#{count} (#{rate} msg/s)")
+      end
+    end)
+
+    elapsed = System.monotonic_time(:millisecond) - start
+    IO.puts("Setup complete: #{count} messages in #{div(elapsed, 1000)}s\n")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strategy 1: Pager (ack_policy: :all, batch fetch, ack last per page)
+  # ---------------------------------------------------------------------------
+  def pager_consume(conn, batch_size) do
+    tab = :ets.new(:pager_cache, [:set])
+
+    {:ok, _} =
+      Gnat.Jetstream.Pager.reduce(conn, @stream, [batch: batch_size], nil, fn msg, acc ->
+        :ets.insert(tab, {msg.topic, msg.body})
+        acc
+      end)
+
+    count = :ets.info(tab, :size)
+    :ets.delete(tab)
+    count
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strategy 2: Pull + ack_next pipeline (ack_policy: :explicit, continuous)
+  # ---------------------------------------------------------------------------
+  def pull_ack_next_consume(conn, batch_size) do
+    {:ok, consumer_info} =
+      Consumer.create(conn, %Consumer{
+        stream_name: @stream,
+        ack_policy: :explicit,
+        deliver_policy: :all,
+        replay_policy: :instant,
+        inactive_threshold: 30_000_000_000
+      })
+
+    total = consumer_info.num_pending
+    inbox = Util.reply_inbox()
+    {:ok, sub} = Gnat.sub(conn, self(), inbox)
+
+    :ok =
+      Consumer.request_next_message(
+        conn,
+        @stream,
+        consumer_info.name,
+        inbox,
+        nil,
+        batch: batch_size,
+        no_wait: true
+      )
+
+    tab = :ets.new(:pull_cache, [:set])
+    receive_with_ack_next(sub, inbox, tab, 0, total)
+
+    count = :ets.info(tab, :size)
+    :ets.delete(tab)
+
+    Gnat.unsub(conn, sub)
+    Consumer.delete(conn, @stream, consumer_info.name)
+
+    count
+  end
+
+  @terminals ["404", "408"]
+
+  defp receive_with_ack_next(_sub, _inbox, _tab, total, total), do: :ok
+
+  defp receive_with_ack_next(sub, inbox, tab, count, total) do
+    receive do
+      {:msg, %{sid: ^sub, status: status}} when status in @terminals ->
+        receive_with_ack_next(sub, inbox, tab, count, total)
+
+      {:msg, %{sid: ^sub, reply_to: nil}} ->
+        receive_with_ack_next(sub, inbox, tab, count, total)
+
+      {:msg, %{sid: ^sub} = message} ->
+        :ets.insert(tab, {message.topic, message.body})
+
+        if count + 1 < total do
+          Gnat.Jetstream.ack_next(message, inbox)
+        else
+          Gnat.Jetstream.ack(message)
+        end
+
+        receive_with_ack_next(sub, inbox, tab, count + 1, total)
+    after
+      30_000 ->
+        IO.puts("WARNING: timeout after receiving #{count}/#{total} messages")
+        :timeout
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strategy 3: PullConsumer with batch_size (ack_policy: :all, batch mode)
+  #
+  # Uses the actual PullConsumer behaviour with the new batch_size option.
+  # This is the real-world usage pattern we want to validate.
+  # ---------------------------------------------------------------------------
+  def batch_pull_consumer_consume(expected, batch_size) do
+    tab = :ets.new(:batch_pc_cache, [:set, :public])
+
+    {:ok, pid} =
+      BenchBatchPullConsumer.start(%{
+        tab: tab,
+        notify: self(),
+        expected: expected,
+        batch_size: batch_size
+      })
+
+    receive do
+      {:done, _received} -> :ok
+    after
+      60_000 ->
+        IO.puts("WARNING: PullConsumer timeout")
+    end
+
+    count = :ets.info(tab, :size)
+    Gnat.Jetstream.PullConsumer.close(pid)
+    :ets.delete(tab)
+    count
+  end
+end
+
+# -- Configuration -----------------------------------------------------------
+
+count = String.to_integer(System.get_env("BENCH_COUNT", "100000"))
+batch = String.to_integer(System.get_env("BENCH_BATCH", "500"))
+time = String.to_integer(System.get_env("BENCH_TIME", "60"))
+
+IO.puts("""
+KV Consume Benchmark
+====================
+Messages:   #{count}
+Batch size: #{batch}
+Time/scenario: #{time}s
+""")
+
+# -- Setup --------------------------------------------------------------------
+
+# Named connection for the PullConsumer
+conn_settings = %{
+  name: :gnat_bench,
+  backoff_period: 1_000,
+  connection_settings: [%{host: '127.0.0.1', port: 4222}]
+}
+
+{:ok, _} = Gnat.ConnectionSupervisor.start_link(conn_settings)
+:timer.sleep(500)
+
+# Direct connection for Pager and manual pull
+{:ok, conn} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+
+KVConsumeBench.setup(conn, count)
+
+# -- Verify all approaches produce correct results ----------------------------
+
+IO.puts("Verifying approaches...")
+
+count1 = KVConsumeBench.pager_consume(conn, batch)
+IO.puts("  Pager:              #{count1} entries")
+
+count2 = KVConsumeBench.pull_ack_next_consume(conn, batch)
+IO.puts("  Pull+ack_next:      #{count2} entries")
+
+count3 = KVConsumeBench.batch_pull_consumer_consume(count, batch)
+IO.puts("  Batch PullConsumer: #{count3} entries")
+
+expected_counts = [count1, count2, count3]
+
+if Enum.any?(expected_counts, &(&1 != count)) do
+  IO.puts("\nERROR: expected #{count} entries from each approach")
+  Gnat.stop(conn)
+  System.halt(1)
+end
+
+IO.puts("\nAll approaches verified. Starting benchmark...\n")
+
+# -- Benchmark ---------------------------------------------------------------
+
+Benchee.run(
+  %{
+    "pager (batch #{batch})" => fn ->
+      KVConsumeBench.pager_consume(conn, batch)
+    end,
+    "pull+ack_next (initial batch #{batch})" => fn ->
+      KVConsumeBench.pull_ack_next_consume(conn, batch)
+    end,
+    "batch_pull_consumer (batch #{batch})" => fn ->
+      KVConsumeBench.batch_pull_consumer_consume(count, batch)
+    end
+  },
+  time: time,
+  warmup: 0,
+  memory_time: 0,
+  formatters: [{Benchee.Formatters.Console, comparisons: true}]
+)
+
+Gnat.stop(conn)

--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -3,6 +3,15 @@ defmodule Gnat.Jetstream.API.KV do
   API for interacting with the Key/Value store functionality in Nats Jetstream.
 
   Learn about the Key/Value store: https://docs.nats.io/nats-concepts/jetstream/key-value-store
+
+  ## Consuming KV changes from a custom PullConsumer
+
+  `watch/3` covers the common "push consumer" use case for reacting to bucket
+  changes. If you need a pull-based consumer instead (e.g. to hydrate a local
+  cache and detect when it is caught up with the stream), see
+  `Gnat.Jetstream.API.KV.Entry` for a shared helper that parses a raw NATS
+  message into a KV operation/key/value triple with optional revision
+  metadata.
   """
   alias Gnat.Jetstream.API.{Stream}
 

--- a/lib/gnat/jetstream/api/kv/entry.ex
+++ b/lib/gnat/jetstream/api/kv/entry.ex
@@ -1,0 +1,149 @@
+defmodule Gnat.Jetstream.API.KV.Entry do
+  @moduledoc """
+  A parsed view of a single message from a Key/Value bucket's underlying stream.
+
+  Messages delivered from a KV bucket's stream encode three different operations
+  (put, delete, purge) using a combination of the `kv-operation` header, the
+  `nats-marker-reason` header, and the absence of any headers. Recovering the
+  original key also requires stripping the `$KV.<bucket>.` subject prefix.
+
+  This module captures that convention in one place so both the built-in
+  `Gnat.Jetstream.API.KV.Watcher` (push consumer) and user-supplied
+  `Gnat.Jetstream.PullConsumer` implementations can share it.
+
+  ## Using with a custom PullConsumer
+
+  A common use case is hydrating a local cache from a KV bucket by driving a
+  `Gnat.Jetstream.PullConsumer`. Inside `c:handle_message/2`, convert the raw
+  message into an `Entry` and branch on the operation:
+
+      defmodule MyApp.KVCache do
+        use Gnat.Jetstream.PullConsumer
+
+        alias Gnat.Jetstream.API.KV
+
+        @bucket "my_bucket"
+
+        @impl true
+        def handle_message(message, state) do
+          case KV.Entry.from_message(message, @bucket) do
+            {:ok, %KV.Entry{operation: :put, key: key, value: value}} ->
+              {:ack, put_in(state.cache[key], value)}
+
+            {:ok, %KV.Entry{operation: op, key: key}} when op in [:delete, :purge] ->
+              {:ack, update_in(state.cache, &Map.delete(&1, key))}
+
+            :ignore ->
+              {:ack, state}
+          end
+        end
+      end
+
+  The returned struct also carries the JetStream `revision` (stream sequence),
+  `created` timestamp, and `delta` (`num_pending`) when the message includes
+  JetStream metadata, which is useful for detecting when the consumer has
+  caught up with the tail of the stream (`delta == 0`).
+
+  ## Messages that are not KV records
+
+  `from_message/2` returns `:ignore` when the input is not a KV record — for
+  example a JetStream status message (`100` heartbeat, `404`/`408` pull
+  terminator, `409` leadership change) or a message whose subject does not
+  belong to the given bucket. In normal operation the `Watcher` and
+  `PullConsumer` layers filter status messages out before they reach user
+  code, so this is a defensive fallback rather than something consumers are
+  expected to rely on.
+  """
+
+  alias Gnat.Jetstream.API.Message
+
+  @operation_header "kv-operation"
+  @operation_del "DEL"
+  @operation_purge "PURGE"
+  @nats_marker_reason_header "nats-marker-reason"
+  @subject_prefix "$KV."
+
+  @type operation :: :put | :delete | :purge
+
+  @type t :: %__MODULE__{
+          bucket: String.t(),
+          key: String.t(),
+          value: binary(),
+          operation: operation(),
+          revision: non_neg_integer() | nil,
+          created: DateTime.t() | nil,
+          delta: non_neg_integer() | nil
+        }
+
+  defstruct [:bucket, :key, :value, :operation, :revision, :created, :delta]
+
+  @doc """
+  Parse a NATS message delivered from a KV bucket's underlying stream into an
+  `Entry`.
+
+  `bucket_name` must match the bucket the message was published to; it is used
+  to strip the `$KV.<bucket>.` subject prefix and recover the key.
+
+  Returns `:ignore` if the message is not a KV record for the given bucket
+  (JetStream status message, wrong subject, etc.).
+
+  The `:revision`, `:created`, and `:delta` fields are populated when the
+  message carries a JetStream `$JS.ACK...` reply subject. For messages without
+  one (e.g. direct get responses), those fields are `nil`.
+  """
+  @spec from_message(Gnat.message(), bucket_name :: String.t()) :: {:ok, t()} | :ignore
+  def from_message(message, bucket_name) do
+    with false <- status_message?(message),
+         {:ok, key} <- extract_key(message, bucket_name) do
+      entry = %__MODULE__{
+        bucket: bucket_name,
+        key: key,
+        value: Map.get(message, :body, ""),
+        operation: operation(message)
+      }
+
+      {:ok, apply_metadata(entry, message)}
+    else
+      _ -> :ignore
+    end
+  end
+
+  defp status_message?(%{status: status}) when is_binary(status) and status != "", do: true
+  defp status_message?(_), do: false
+
+  defp extract_key(%{topic: topic}, bucket_name) do
+    prefix = @subject_prefix <> bucket_name <> "."
+
+    if String.starts_with?(topic, prefix) do
+      {:ok, binary_part(topic, byte_size(prefix), byte_size(topic) - byte_size(prefix))}
+    else
+      :error
+    end
+  end
+
+  defp operation(%{headers: headers}) when is_list(headers) do
+    Enum.find_value(headers, :put, fn
+      {@operation_header, @operation_del} -> :delete
+      {@operation_header, @operation_purge} -> :purge
+      {@nats_marker_reason_header, _} -> :delete
+      _ -> false
+    end)
+  end
+
+  defp operation(_message), do: :put
+
+  defp apply_metadata(entry, message) do
+    case Message.metadata(message) do
+      {:ok, metadata} ->
+        %__MODULE__{
+          entry
+          | revision: metadata.stream_seq,
+            created: metadata.timestamp,
+            delta: metadata.num_pending
+        }
+
+      {:error, _} ->
+        entry
+    end
+  end
+end

--- a/lib/gnat/jetstream/api/kv/watcher.ex
+++ b/lib/gnat/jetstream/api/kv/watcher.ex
@@ -9,11 +9,13 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
   use GenServer
 
   alias Gnat.Jetstream.API.{Consumer, KV, Util}
+  alias Gnat.Jetstream.API.KV.Entry
 
-  @operation_header "kv-operation"
-  @operation_del "DEL"
-  @operation_purge "PURGE"
-  @nats_marker_reason_header "nats-marker-reason"
+  # Matches the ordered-consumer defaults used by the nats.go KV watcher:
+  # a 5s idle heartbeat and server-driven flow control. The flow-control
+  # messages arrive as 100-status messages with a reply subject — the client
+  # is expected to publish an empty reply so the server releases backpressure.
+  @flow_control_heartbeat_ns 5_000_000_000
 
   @type keywatch_handler ::
           (action :: :key_deleted | :key_added, key :: String.t(), value :: any() -> nil)
@@ -52,41 +54,38 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
     :ok = Consumer.delete(state.conn, stream, state.consumer_name, state.domain)
   end
 
-  # Received from NATS when headers are on the message (delete)
-  def handle_info({:msg, %{topic: key, body: body, headers: headers}}, state) do
-    key = KV.subject_to_key(key, state.bucket_name)
+  # Flow-control request: the server is asking us to acknowledge that we're
+  # keeping up. Responding releases backpressure so the server continues
+  # delivering messages to slow handlers rather than dropping us as a slow
+  # consumer.
+  def handle_info({:msg, %{status: "100", reply_to: reply_to}}, state)
+      when is_binary(reply_to) and reply_to != "" do
+    :ok = Gnat.pub(state.conn, reply_to, "")
+    {:noreply, state}
+  end
 
-    notification =
-      Enum.find_value(headers, fn
-        {@operation_header, @operation_del} ->
-          :key_deleted
+  # Idle heartbeat (status 100 with no reply_to) and any other informational
+  # status message (404, 408, 409, etc.) — not a stream record, drop it.
+  def handle_info({:msg, %{status: status}}, state)
+      when is_binary(status) and status != "" do
+    {:noreply, state}
+  end
 
-        {@operation_header, @operation_purge} ->
-          :key_purged
+  def handle_info({:msg, message}, state) do
+    case Entry.from_message(message, state.bucket_name) do
+      {:ok, entry} ->
+        state.handler.(action(entry.operation), entry.key, entry.value)
 
-        {@nats_marker_reason_header, _} ->
-          :key_deleted
-
-        _ ->
-          false
-      end)
-
-    if notification do
-      state.handler.(notification, key, body)
-    else
-      state.handler.(:key_added, key, body)
+      :ignore ->
+        :ok
     end
 
     {:noreply, state}
   end
 
-  # Received from NATS with no headers (add)
-  def handle_info({:msg, %{topic: key, body: body}}, state) do
-    key = KV.subject_to_key(key, state.bucket_name)
-
-    state.handler.(:key_added, key, body)
-    {:noreply, state}
-  end
+  defp action(:put), do: :key_added
+  defp action(:delete), do: :key_deleted
+  defp action(:purge), do: :key_purged
 
   defp subscribe(conn, bucket_name) do
     stream = KV.stream_name(bucket_name)
@@ -101,7 +100,9 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
              stream_name: stream,
              ack_policy: :none,
              max_ack_pending: -1,
-             max_deliver: 1
+             max_deliver: 1,
+             flow_control: true,
+             idle_heartbeat: @flow_control_heartbeat_ns
            }) do
       {:ok, {sub, consumer_name}}
     end

--- a/lib/gnat/jetstream/pager.ex
+++ b/lib/gnat/jetstream/pager.ex
@@ -33,7 +33,7 @@ defmodule Gnat.Jetstream.Pager do
 
   @spec init(Gnat.t(), String.t(), opts()) :: {:ok, pager()} | {:error, term()}
   def init(conn, stream_name, opts) do
-    domain = Keyword.get(opts, :domainl)
+    domain = Keyword.get(opts, :domain)
 
     consumer = %Consumer{
       stream_name: stream_name,
@@ -75,9 +75,8 @@ defmodule Gnat.Jetstream.Pager do
   end
 
   def cleanup(%{conn: conn} = state) do
-    with :ok <- Gnat.unsub(conn, state.sub) do
-      :ok = Consumer.delete(conn, state.stream_name, state.consumer_name, state.domain)
-    end
+    :ok = Gnat.unsub(conn, state.sub)
+    Consumer.delete(conn, state.stream_name, state.consumer_name, state.domain)
   end
 
   @doc """
@@ -114,7 +113,7 @@ defmodule Gnat.Jetstream.Pager do
 
       {:done, messages} ->
         new_state = Enum.reduce(messages, state, fun)
-        :ok = cleanup(pager)
+        cleanup(pager)
         {:ok, new_state}
     end
   end

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -85,6 +85,10 @@ defmodule Gnat.Jetstream.PullConsumer do
     on large backlogs. In batch mode, `:nack` and `:term` returns from `c:handle_message/2`
     are treated as `:ack` since `ack_policy: :all` cannot selectively reject messages.
     Defaults to `1` (single-message mode).
+  * `:request_expires` - duration in nanoseconds a batch-mode pull request will linger on
+    the server while tailing (no backlog) before the server replies with a `408` terminator
+    and the consumer issues a fresh pull. Only used when `:batch_size` is greater than 1.
+    Defaults to `5_000_000_000` (5 seconds).
 
   ## Dynamic Connection Options
 
@@ -361,6 +365,7 @@ defmodule Gnat.Jetstream.PullConsumer do
           | {:connection_retries, non_neg_integer()}
           | {:domain, String.t()}
           | {:batch_size, pos_integer()}
+          | {:request_expires, non_neg_integer()}
 
   @typedoc """
   Connection options used to connect the consumer to NATS server.

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -243,6 +243,11 @@ defmodule Gnat.Jetstream.PullConsumer do
   Invoked to synchronously process a message pulled by the consumer.
   Depending on the value it returns, the acknowledgement is or is not sent.
 
+  Only real stream messages reach this callback. JetStream informational
+  status messages (e.g. `100` heartbeat, `404`/`408` pull terminator, `409`
+  leadership change) are intercepted by the consumer and never passed here.
+  See `c:handle_status/2` if you want to observe them.
+
   ## ACK actions
 
   Possible ACK actions values explained:
@@ -302,7 +307,42 @@ defmodule Gnat.Jetstream.PullConsumer do
               state :: term()
             ) :: {:ok, new_state :: term()}
 
-  @optional_callbacks [handle_connected: 2]
+  @doc """
+  Invoked when the consumer receives an informational JetStream status message
+  instead of a real stream message.
+
+  JetStream delivers status messages on the same subscription as regular
+  messages — for example a `100` idle heartbeat, a `404`/`408` pull request
+  terminator, or a `409` leadership change. These are not stream records and
+  cannot be acked, so the PullConsumer never forwards them to `c:handle_message/2`.
+
+  By default they are silently dropped and the consumer continues fetching
+  the next message. Implement this callback if you want to observe them — for
+  example to log a warning on leadership changes, or to track heartbeat
+  arrival.
+
+  The callback receives the raw `Gnat.message()` (which includes `:status`
+  and optionally `:description`) and the current state. Returning
+  `{:ok, new_state}` updates the state; the consumer then proceeds the same
+  way it would have if the callback had not been defined.
+
+  This callback is optional.
+
+  ## Example
+
+      @impl true
+      def handle_status(%{status: "409", description: description}, state) do
+        Logger.warning("JetStream 409 from consumer: #\{description}")
+        {:ok, state}
+      end
+
+      def handle_status(_message, state), do: {:ok, state}
+
+  """
+  @callback handle_status(message :: Gnat.message(), state :: term()) ::
+              {:ok, new_state :: term()}
+
+  @optional_callbacks [handle_connected: 2, handle_status: 2]
 
   @typedoc """
   The pull consumer reference.

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -268,6 +268,42 @@ defmodule Gnat.Jetstream.PullConsumer do
               {ack_action, new_state}
             when ack_action: :ack | :nack | :term | :noreply, new_state: term()
 
+  @doc """
+  Invoked after the consumer has been created or verified on the NATS server.
+
+  This callback is called during connection (and reconnection) after the JetStream
+  consumer has been successfully created or confirmed to exist. It receives the full
+  consumer info map returned by the server, which includes fields like `num_pending`
+  (the number of messages waiting to be delivered).
+
+  This is useful for detecting the initial state of the consumer. For example, if
+  `num_pending` is `0`, you know there are no existing messages to replay and can
+  mark the consumer as caught up immediately.
+
+  Returning `{:ok, state}` allows you to update the consumer's state based on the
+  consumer info.
+
+  This callback is optional. If not implemented, the state is passed through unchanged.
+
+  ## Example
+
+      @impl true
+      def handle_connected(consumer_info, state) do
+        if consumer_info.num_pending == 0 do
+          {:ok, mark_as_loaded(state)}
+        else
+          {:ok, state}
+        end
+      end
+
+  """
+  @callback handle_connected(
+              consumer_info :: Gnat.Jetstream.API.Consumer.info(),
+              state :: term()
+            ) :: {:ok, new_state :: term()}
+
+  @optional_callbacks [handle_connected: 2]
+
   @typedoc """
   The pull consumer reference.
   """

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -78,6 +78,13 @@ defmodule Gnat.Jetstream.PullConsumer do
     defaults to `10`
   * `:inbox_prefix` - allows the default `_INBOX.` prefix to be customized. Should end with a dot.
   * `:domain` - use a JetStream domain, this is mostly used on leaf nodes.
+  * `:batch_size` - when set to a value greater than 1, enables batch mode. Messages are
+    buffered and delivered to `c:handle_message/2` in batches. Only the last message per
+    batch is acknowledged, so the underlying consumer should use `ack_policy: :all` for
+    correctness. This dramatically improves throughput for consumers that need to catch up
+    on large backlogs. In batch mode, `:nack` and `:term` returns from `c:handle_message/2`
+    are treated as `:ack` since `ack_policy: :all` cannot selectively reject messages.
+    Defaults to `1` (single-message mode).
 
   ## Dynamic Connection Options
 
@@ -277,6 +284,7 @@ defmodule Gnat.Jetstream.PullConsumer do
           | {:connection_retry_timeout, non_neg_integer()}
           | {:connection_retries, non_neg_integer()}
           | {:domain, String.t()}
+          | {:batch_size, pos_integer()}
 
   @typedoc """
   Connection options used to connect the consumer to NATS server.

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -12,7 +12,17 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
     :domain
   ]
 
-  defstruct @enforce_keys ++ [:stream_name, :consumer_name, :consumer, batch_size: 1]
+  # 5 Seconds in nanoseconds
+  @default_request_expires 5_000_000_000
+
+  defstruct @enforce_keys ++
+              [
+                :stream_name,
+                :consumer_name,
+                :consumer,
+                batch_size: 1,
+                request_expires: @default_request_expires
+              ]
 
   def validate!(connection_options) do
     validated_opts =
@@ -25,7 +35,8 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
         connection_retries: @default_retries,
         inbox_prefix: nil,
         domain: nil,
-        batch_size: 1
+        batch_size: 1,
+        request_expires: @default_request_expires
       ])
 
     stream_name = validated_opts[:stream_name]
@@ -43,6 +54,13 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
       consumer && consumer.durable_name != nil && consumer.inactive_threshold == nil ->
         raise ArgumentError,
               "durable consumers specified via :consumer must have inactive_threshold set for auto-cleanup"
+
+      consumer && validated_opts[:batch_size] > 1 && consumer.ack_policy != :all ->
+        raise ArgumentError,
+              "batch_size > 1 requires ack_policy: :all on the consumer, " <>
+                "got: #{inspect(consumer.ack_policy)}. With ack_policy: :explicit, " <>
+                "only the last message in each batch would be acknowledged and the " <>
+                "server would redeliver the rest"
 
       consumer ->
         # For ephemeral/auto-cleanup consumer case, extract stream_name from consumer struct

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -12,7 +12,7 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
     :domain
   ]
 
-  defstruct @enforce_keys ++ [:stream_name, :consumer_name, :consumer]
+  defstruct @enforce_keys ++ [:stream_name, :consumer_name, :consumer, batch_size: 1]
 
   def validate!(connection_options) do
     validated_opts =
@@ -24,7 +24,8 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
         connection_retry_timeout: @default_retry_timeout,
         connection_retries: @default_retries,
         inbox_prefix: nil,
-        domain: nil
+        domain: nil,
+        batch_size: 1
       ])
 
     stream_name = validated_opts[:stream_name]

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -260,41 +260,43 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
-  # -- Batch mode: terminal signal (404/408) means the batch request is complete --
-  @batch_terminals ["404", "408"]
-
+  # -- Batch mode: 100 is an idle heartbeat — the pull is still alive, do
+  # nothing but invoke the user callback. --
   def handle_info(
-        {:msg, %{status: status, gnat: gnat}},
+        {:msg, %{status: "100"} = message},
+        %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
+      )
+      when batch_size > 1 do
+    gen_state = maybe_handle_status(message, gen_state)
+    {:noreply, gen_state}
+  end
+
+  # -- Batch mode: any other status (404/408 terminators, 409 leadership
+  # change / max_ack_pending / max_waiting / consumer-deleted, etc.) ends
+  # the outstanding pull request. Process any partial buffer and issue a
+  # new pull so the consumer doesn't stall. --
+  def handle_info(
+        {:msg, %{status: status, gnat: gnat} = message},
         %__MODULE__{
           connection_options: %ConnectionOptions{batch_size: batch_size},
           buffer: buffer
         } = gen_state
       )
-      when batch_size > 1 and status in @batch_terminals do
+      when batch_size > 1 and is_binary(status) and status != "" do
+    gen_state = maybe_handle_status(message, gen_state)
+
     case buffer do
       [] ->
-        # Fully caught up — long-poll for new messages
+        # Nothing buffered — long-poll for new messages.
         request_batch(gnat, gen_state, :tailing)
         {:noreply, gen_state}
 
       _messages ->
-        # Partial batch — process what we have, then try for more
+        # Partial batch — process what we have, then try for more.
         gen_state = process_and_ack_batch(gen_state)
         request_batch(gnat, gen_state, :catching_up)
         {:noreply, gen_state}
     end
-  end
-
-  # -- Batch mode: non-terminator informational status (e.g. 100 heartbeat, 409
-  # leadership change). Drop it — these aren't stream records and can't be
-  # acked. The batch continues waiting for real messages or a 404/408. --
-  def handle_info(
-        {:msg, %{status: status} = message},
-        %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
-      )
-      when batch_size > 1 and is_binary(status) and status != "" do
-    gen_state = maybe_handle_status(message, gen_state)
-    {:noreply, gen_state}
   end
 
   # -- Single-message mode: informational status. Drop + re-pull so the

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -400,11 +400,13 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     )
 
     # Clear consumer name on reconnect so it gets recreated (for ephemeral and auto-cleanup consumers)
+    # Clear buffer to avoid processing stale messages from the dead connection
     gen_state = %{
       gen_state
       | consumer_name: nil,
         subscription_id: nil,
-        connection_monitor_ref: nil
+        connection_monitor_ref: nil,
+        buffer: []
     }
 
     {:connect, :reconnect, gen_state}

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -72,7 +72,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
 
     with {:ok, conn} <- connection_pid(connection_name),
          monitor_ref = Process.monitor(conn),
-         {:ok, final_consumer_name} <-
+         {:ok, consumer_info} <-
            ensure_consumer_exists(
              conn,
              stream_name,
@@ -80,12 +80,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
              consumer,
              domain
            ),
+         final_consumer_name = consumer_info.name,
+         state = maybe_handle_connected(module, consumer_info, gen_state.state),
          {:ok, sid} <- Gnat.sub(conn, self(), listening_topic),
          gen_state = %{
            gen_state
            | subscription_id: sid,
              connection_monitor_ref: monitor_ref,
-             consumer_name: final_consumer_name
+             consumer_name: final_consumer_name,
+             state: state
          },
          :ok <-
            initial_fetch(
@@ -169,8 +172,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
   defp ensure_consumer_exists(gnat, stream_name, consumer_name, nil, domain) do
     # Durable consumer case - just check it exists
     try do
-      case check_consumer_exists(gnat, stream_name, consumer_name, domain) do
-        :ok -> {:ok, consumer_name}
+      case Gnat.Jetstream.API.Consumer.info(gnat, stream_name, consumer_name, domain) do
+        {:ok, consumer_info} -> {:ok, consumer_info}
         {:error, reason} -> {:error, reason}
       end
     catch
@@ -184,7 +187,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     try do
       with {:ok, consumer_definition} <- validate_consumer_for_creation(consumer_struct),
            {:ok, consumer_info} <- Gnat.Jetstream.API.Consumer.create(gnat, consumer_definition) do
-        {:ok, consumer_info.name}
+        {:ok, consumer_info}
       end
     catch
       :exit, reason -> {:error, {:process_exit, reason}}
@@ -206,13 +209,12 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
-  defp check_consumer_exists(gnat, stream_name, consumer_name, domain) do
-    case Gnat.Jetstream.API.Consumer.info(gnat, stream_name, consumer_name, domain) do
-      {:ok, _consumer} ->
-        :ok
-
-      {:error, message} ->
-        {:error, message}
+  defp maybe_handle_connected(module, consumer_info, state) do
+    if function_exported?(module, :handle_connected, 2) do
+      {:ok, state} = module.handle_connected(consumer_info, state)
+      state
+    else
+      state
     end
   end
 

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -236,6 +236,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
+  defp maybe_handle_status(message, %__MODULE__{module: module, state: state} = gen_state) do
+    if function_exported?(module, :handle_status, 2) do
+      {:ok, new_state} = module.handle_status(message, state)
+      %{gen_state | state: new_state}
+    else
+      gen_state
+    end
+  end
+
   defp connection_pid(connection_name) when is_pid(connection_name) do
     if Process.alive?(connection_name) do
       {:ok, connection_name}
@@ -274,6 +283,46 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         request_batch(gnat, gen_state, :catching_up)
         {:noreply, gen_state}
     end
+  end
+
+  # -- Batch mode: non-terminator informational status (e.g. 100 heartbeat, 409
+  # leadership change). Drop it — these aren't stream records and can't be
+  # acked. The batch continues waiting for real messages or a 404/408. --
+  def handle_info(
+        {:msg, %{status: status} = message},
+        %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
+      )
+      when batch_size > 1 and is_binary(status) and status != "" do
+    gen_state = maybe_handle_status(message, gen_state)
+    {:noreply, gen_state}
+  end
+
+  # -- Single-message mode: informational status. Drop + re-pull so the
+  # consumer doesn't stall. Matches the nats.go convention of never exposing
+  # status messages to the user's message handler. --
+  def handle_info(
+        {:msg, %{status: status} = message},
+        %__MODULE__{
+          connection_options: %ConnectionOptions{
+            stream_name: stream_name,
+            domain: domain
+          },
+          listening_topic: listening_topic,
+          consumer_name: consumer_name
+        } = gen_state
+      )
+      when is_binary(status) and status != "" do
+    gen_state = maybe_handle_status(message, gen_state)
+
+    next_message(
+      message.gnat,
+      stream_name,
+      consumer_name,
+      domain,
+      listening_topic
+    )
+
+    {:noreply, gen_state}
   end
 
   # -- Batch mode: data message — buffer until batch is full --

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -80,6 +80,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
              consumer,
              domain
            ),
+         :ok <- validate_batch_ack_policy(gen_state.connection_options, consumer_info),
          final_consumer_name = consumer_info.name,
          state = maybe_handle_connected(module, consumer_info, gen_state.state),
          {:ok, sid} <- Gnat.sub(conn, self(), listening_topic),
@@ -208,6 +209,23 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         {:ok, consumer_definition}
     end
   end
+
+  defp validate_batch_ack_policy(%ConnectionOptions{batch_size: batch_size}, consumer_info)
+       when batch_size > 1 do
+    case consumer_info.config.ack_policy do
+      :all ->
+        :ok
+
+      other ->
+        {:error,
+         "batch_size > 1 requires ack_policy: :all on the consumer, " <>
+           "got: #{inspect(other)}. With ack_policy: :explicit, " <>
+           "only the last message in each batch would be acknowledged and the " <>
+           "server would redeliver the rest"}
+    end
+  end
+
+  defp validate_batch_ack_policy(_connection_options, _consumer_info), do: :ok
 
   defp maybe_handle_connected(module, consumer_info, state) do
     if function_exported?(module, :handle_connected, 2) do
@@ -461,14 +479,13 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
-  @five_seconds_ns 5_000_000_000
-
   defp request_batch(conn, gen_state, mode) do
     %{
       connection_options: %ConnectionOptions{
         stream_name: stream_name,
         batch_size: batch_size,
-        domain: domain
+        domain: domain,
+        request_expires: expires
       },
       consumer_name: consumer_name,
       listening_topic: listening_topic
@@ -477,7 +494,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     opts =
       case mode do
         :catching_up -> [batch: batch_size, no_wait: true]
-        :tailing -> [batch: batch_size, expires: @five_seconds_ns]
+        :tailing -> [batch: batch_size, expires: expires]
       end
 
     Gnat.Jetstream.API.Consumer.request_next_message(

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -16,7 +16,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     :subscription_id,
     :connection_monitor_ref,
     :consumer_name,
-    current_retry: 0
+    current_retry: 0,
+    buffer: []
   ]
 
   def init(%{module: module, init_arg: init_arg}) do
@@ -86,7 +87,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
              connection_monitor_ref: monitor_ref,
              consumer_name: final_consumer_name
          },
-         :ok <- next_message(conn, stream_name, final_consumer_name, domain, listening_topic),
+         :ok <-
+           initial_fetch(
+             gen_state,
+             conn,
+             stream_name,
+             final_consumer_name,
+             domain,
+             listening_topic
+           ),
          gen_state = %{gen_state | current_retry: 0} do
       {:ok, gen_state}
     else
@@ -222,6 +231,53 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
+  # -- Batch mode: terminal signal (404/408) means the batch request is complete --
+  @batch_terminals ["404", "408"]
+
+  def handle_info(
+        {:msg, %{status: status, gnat: gnat}},
+        %__MODULE__{
+          connection_options: %ConnectionOptions{batch_size: batch_size},
+          buffer: buffer
+        } = gen_state
+      )
+      when batch_size > 1 and status in @batch_terminals do
+    case buffer do
+      [] ->
+        # Fully caught up — long-poll for new messages
+        request_batch(gnat, gen_state, :tailing)
+        {:noreply, gen_state}
+
+      _messages ->
+        # Partial batch — process what we have, then try for more
+        gen_state = process_and_ack_batch(gen_state)
+        request_batch(gnat, gen_state, :catching_up)
+        {:noreply, gen_state}
+    end
+  end
+
+  # -- Batch mode: data message — buffer until batch is full --
+  def handle_info(
+        {:msg, message},
+        %__MODULE__{
+          connection_options: %ConnectionOptions{batch_size: batch_size},
+          buffer: buffer
+        } = gen_state
+      )
+      when batch_size > 1 do
+    buffer = [message | buffer]
+    gen_state = %{gen_state | buffer: buffer}
+
+    if length(buffer) >= batch_size do
+      gen_state = process_and_ack_batch(gen_state)
+      request_batch(message.gnat, gen_state, :catching_up)
+      {:noreply, gen_state}
+    else
+      {:noreply, gen_state}
+    end
+  end
+
+  # -- Single-message mode (batch_size == 1, the default) --
   def handle_info(
         {:msg, message},
         %__MODULE__{
@@ -393,5 +449,67 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
       listening_topic,
       domain
     )
+  end
+
+  defp initial_fetch(gen_state, conn, stream_name, consumer_name, domain, listening_topic) do
+    if gen_state.connection_options.batch_size > 1 do
+      request_batch(conn, gen_state, :catching_up)
+    else
+      next_message(conn, stream_name, consumer_name, domain, listening_topic)
+    end
+  end
+
+  @five_seconds_ns 5_000_000_000
+
+  defp request_batch(conn, gen_state, mode) do
+    %{
+      connection_options: %ConnectionOptions{
+        stream_name: stream_name,
+        batch_size: batch_size,
+        domain: domain
+      },
+      consumer_name: consumer_name,
+      listening_topic: listening_topic
+    } = gen_state
+
+    opts =
+      case mode do
+        :catching_up -> [batch: batch_size, no_wait: true]
+        :tailing -> [batch: batch_size, expires: @five_seconds_ns]
+      end
+
+    Gnat.Jetstream.API.Consumer.request_next_message(
+      conn,
+      stream_name,
+      consumer_name,
+      listening_topic,
+      domain,
+      opts
+    )
+  end
+
+  defp process_and_ack_batch(%{buffer: buffer, module: module, state: state} = gen_state) do
+    messages = Enum.reverse(buffer)
+
+    new_state =
+      Enum.reduce(messages, state, fn message, acc_state ->
+        case module.handle_message(message, acc_state) do
+          {:ack, updated_state} ->
+            updated_state
+
+          {action, updated_state} ->
+            Logger.warning(
+              "PullConsumer batch mode does not support #{inspect(action)}, treating as :ack"
+            )
+
+            updated_state
+        end
+      end)
+
+    # With ack_policy: :all, acking the last message covers the entire batch
+    last = List.last(messages)
+    Gnat.Jetstream.ack(last)
+
+    %{gen_state | state: new_state, buffer: []}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nats-io/nats.ex"
-  @version "1.14.0-rc0"
+  @version "1.14.0-rc1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nats-io/nats.ex"
-  @version "1.14.0-rc1"
+  @version "1.14.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nats-io/nats.ex"
-  @version "1.13.1"
+  @version "1.14.0-rc0"
 
   def project do
     [
@@ -85,7 +85,8 @@ defmodule Gnat.Mixfile do
         "Garrett Thornburg",
         "Masahiro Tokioka",
         "Kevin Hoffman"
-      ]
+      ],
+      exclude_patterns: ["priv/plts"]
     ]
   end
 end

--- a/scripts/cluster/cluster.sh
+++ b/scripts/cluster/cluster.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Minimal control script for a 3-node local nats cluster used for
+# manually exercising PullConsumer failover behavior.
+#
+# Usage:
+#   scripts/cluster/cluster.sh start           # start all 3
+#   scripts/cluster/cluster.sh start n1        # start just n1
+#   scripts/cluster/cluster.sh stop            # stop all 3 (SIGTERM)
+#   scripts/cluster/cluster.sh stop n2         # stop just n2
+#   scripts/cluster/cluster.sh kill n2         # SIGKILL n2 (hard fail)
+#   scripts/cluster/cluster.sh status          # show what's running
+#   scripts/cluster/cluster.sh clean           # stop all + wipe data dirs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PID_DIR="$SCRIPT_DIR/pids"
+LOG_DIR="$SCRIPT_DIR/logs"
+DATA_DIR="$SCRIPT_DIR/data"
+
+mkdir -p "$PID_DIR" "$LOG_DIR" "$DATA_DIR"
+
+nodes=(n1 n2 n3)
+
+port_for() {
+  case "$1" in
+    n1) echo 4223 ;;
+    n2) echo 4224 ;;
+    n3) echo 4225 ;;
+    *)  echo "unknown node: $1" >&2; return 1 ;;
+  esac
+}
+
+is_running() {
+  local node=$1
+  local pidfile="$PID_DIR/$node.pid"
+  [[ -f "$pidfile" ]] || return 1
+  local pid
+  pid=$(cat "$pidfile")
+  kill -0 "$pid" 2>/dev/null
+}
+
+start_node() {
+  local node=$1
+  if is_running "$node"; then
+    echo "$node already running (pid $(cat "$PID_DIR/$node.pid"))"
+    return 0
+  fi
+
+  local conf="$SCRIPT_DIR/$node.conf"
+  local log="$LOG_DIR/$node.log"
+  local pidfile="$PID_DIR/$node.pid"
+
+  # Run from repo root so the relative store_dir in the conf resolves.
+  (
+    cd "$REPO_ROOT"
+    nohup nats-server -c "$conf" >"$log" 2>&1 &
+    echo $! > "$pidfile"
+  )
+  sleep 0.3
+  if is_running "$node"; then
+    echo "$node started (pid $(cat "$pidfile"), port $(port_for "$node"), log $log)"
+  else
+    echo "$node failed to start — check $log" >&2
+    return 1
+  fi
+}
+
+stop_node() {
+  local node=$1
+  local signal=${2:-TERM}
+  if ! is_running "$node"; then
+    echo "$node not running"
+    rm -f "$PID_DIR/$node.pid"
+    return 0
+  fi
+  local pid
+  pid=$(cat "$PID_DIR/$node.pid")
+  kill "-$signal" "$pid"
+  echo "$node sent SIG$signal (pid $pid)"
+  rm -f "$PID_DIR/$node.pid"
+}
+
+status() {
+  for node in "${nodes[@]}"; do
+    if is_running "$node"; then
+      echo "$node  RUNNING  pid=$(cat "$PID_DIR/$node.pid")  port=$(port_for "$node")"
+    else
+      echo "$node  stopped              port=$(port_for "$node")"
+    fi
+  done
+}
+
+cmd=${1:-}
+shift || true
+
+targets=()
+if (( $# > 0 )); then
+  targets=("$@")
+else
+  targets=("${nodes[@]}")
+fi
+
+case "$cmd" in
+  start)
+    for n in "${targets[@]}"; do start_node "$n"; done
+    ;;
+  stop)
+    for n in "${targets[@]}"; do stop_node "$n" TERM; done
+    ;;
+  kill)
+    for n in "${targets[@]}"; do stop_node "$n" KILL; done
+    ;;
+  status)
+    status
+    ;;
+  clean)
+    for n in "${nodes[@]}"; do stop_node "$n" KILL || true; done
+    rm -rf "$DATA_DIR" "$LOG_DIR" "$PID_DIR"
+    echo "cleaned data, logs, pids"
+    ;;
+  *)
+    echo "usage: $0 {start|stop|kill|status|clean} [n1|n2|n3]..." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/cluster/driver.exs
+++ b/scripts/cluster/driver.exs
@@ -93,7 +93,7 @@ defmodule FailoverConsumer do
 
   @impl true
   def init(opts) do
-    {:ok, %{count: 0, batch: 10}, opts}
+    {:ok, %{count: 0, batch_size: 10}, opts}
   end
 
   @impl true

--- a/scripts/cluster/driver.exs
+++ b/scripts/cluster/driver.exs
@@ -1,0 +1,186 @@
+# Manual failover driver for the 3-node cluster under scripts/cluster/.
+#
+# Usage (from repo root, after `scripts/cluster/cluster.sh start`):
+#
+#   mix run --no-halt scripts/cluster/driver.exs
+#
+# The script:
+#   * connects to 2 of the 3 cluster nodes via Gnat.ConnectionSupervisor
+#   * creates (if needed) a 3-replica stream "FAILOVER_STREAM" and a durable
+#     consumer "FAILOVER_CONSUMER"
+#   * starts a PullConsumer that logs every delivery
+#   * publishes a numbered message every second
+#
+# Watch the logs, then in another terminal run:
+#   scripts/cluster/cluster.sh kill n1
+#   scripts/cluster/cluster.sh start n1
+#   scripts/cluster/cluster.sh kill n2
+# …and verify the consumer keeps receiving messages.
+
+require Logger
+Logger.configure(level: :info)
+
+alias Gnat.Jetstream.API.{Consumer, Stream}
+
+stream_name = "FAILOVER_STREAM"
+consumer_name = "FAILOVER_CONSUMER"
+subject = "failover.test"
+
+# Deliberately point at only 2 of the 3 nodes so we can prove the connection
+# can still reach the cluster even when one of the listed nodes is down.
+connection_settings = [
+  %{host: ~c"127.0.0.1", port: 4223},
+  %{host: ~c"127.0.0.1", port: 4224}
+]
+
+{:ok, _sup} =
+  Gnat.ConnectionSupervisor.start_link(
+    %{
+      name: :gnat,
+      backoff_period: 1_000,
+      connection_settings: connection_settings
+    },
+    name: :gnat_sup
+  )
+
+# Wait until the connection is actually established before issuing JS admin calls.
+wait_for_gnat = fn wait_for_gnat ->
+  case Process.whereis(:gnat) do
+    nil ->
+      Process.sleep(100)
+      wait_for_gnat.(wait_for_gnat)
+
+    pid when is_pid(pid) ->
+      :ok
+  end
+end
+
+wait_for_gnat.(wait_for_gnat)
+Logger.info("connected to cluster")
+
+# Create (or reuse) a 3-replica stream + durable consumer.
+stream = %Stream{
+  name: stream_name,
+  subjects: [subject],
+  num_replicas: 3,
+  storage: :file
+}
+
+case Stream.create(:gnat, stream) do
+  {:ok, _} -> Logger.info("created stream #{stream_name}")
+  {:error, %{"err_code" => 10058}} -> Logger.info("stream #{stream_name} already exists")
+  {:error, other} -> Logger.warning("stream create returned: #{inspect(other)}")
+end
+
+consumer = %Consumer{
+  stream_name: stream_name,
+  durable_name: consumer_name,
+  ack_policy: :all
+}
+
+case Consumer.create(:gnat, consumer) do
+  {:ok, _} -> Logger.info("created consumer #{consumer_name}")
+  {:error, %{"err_code" => 10148}} -> Logger.info("consumer #{consumer_name} already exists")
+  {:error, other} -> Logger.warning("consumer create returned: #{inspect(other)}")
+end
+
+# ---------- The PullConsumer under test ----------
+defmodule FailoverConsumer do
+  use Gnat.Jetstream.PullConsumer
+  require Logger
+
+  def start_link(opts), do: Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+
+  @impl true
+  def init(opts) do
+    {:ok, %{count: 0, batch: 10}, opts}
+  end
+
+  @impl true
+  def handle_message(%{body: body, reply_to: reply_to}, state) do
+    # reply_to carries delivery metadata: $JS.ACK.<stream>.<consumer>.<delivered>.<stream_seq>.<consumer_seq>.<ts>.<pending>
+    meta =
+      case reply_to do
+        "$JS.ACK." <> rest -> rest
+        other -> other
+      end
+
+    Logger.info("RECV ##{state.count + 1} body=#{inspect(body)} meta=#{meta}")
+    {:ack, %{state | count: state.count + 1}}
+  end
+
+  @impl true
+  def handle_status(%{status: status, description: desc}, state) do
+    Logger.warning("STATUS #{status} #{desc}")
+    {:ok, state}
+  end
+
+  def handle_status(%{status: status}, state) do
+    Logger.warning("STATUS #{status}")
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_connected(consumer_info, state) do
+    Logger.info("connected, num_pending=#{consumer_info.num_pending}")
+    {:ok, state}
+  end
+end
+
+{:ok, _pc} =
+  FailoverConsumer.start_link(
+    connection_name: :gnat,
+    stream_name: stream_name,
+    consumer_name: consumer_name
+  )
+
+Logger.info("PullConsumer started; publishing one message per second")
+
+# ---------- Publisher loop ----------
+# Uses Gnat.request so we wait for the JetStream publish ack. We only bump
+# the accepted counter when the server confirms the write — that way RECV
+# numbers track actual stream writes, not best-effort pub attempts.
+defmodule Publisher do
+  require Logger
+
+  def loop(subject, attempt \\ 1, accepted \\ 0) do
+    body = "msg-#{accepted + 1}-#{System.system_time(:millisecond)}"
+
+    result =
+      try do
+        Gnat.request(:gnat, subject, body, receive_timeout: 2_000)
+      catch
+        :exit, reason -> {:error, {:exit, reason}}
+      end
+
+    case result do
+      {:ok, %{body: resp_body}} ->
+        case Jason.decode(resp_body) do
+          {:ok, %{"stream" => stream, "seq" => seq}} ->
+            Logger.info("PUB  ##{accepted + 1} ok stream=#{stream} seq=#{seq} body=#{body}")
+            Process.sleep(1_000)
+            loop(subject, attempt + 1, accepted + 1)
+
+          {:ok, %{"error" => err}} ->
+            Logger.warning(
+              "PUB attempt ##{attempt} rejected by server: #{inspect(err)} body=#{body}"
+            )
+
+            Process.sleep(1_000)
+            loop(subject, attempt + 1, accepted)
+
+          other ->
+            Logger.warning("PUB attempt ##{attempt} unparsable ack: #{inspect(other)}")
+            Process.sleep(1_000)
+            loop(subject, attempt + 1, accepted)
+        end
+
+      {:error, reason} ->
+        Logger.warning("PUB attempt ##{attempt} failed: #{inspect(reason)} body=#{body}")
+        Process.sleep(1_000)
+        loop(subject, attempt + 1, accepted)
+    end
+  end
+end
+
+Publisher.loop(subject)

--- a/scripts/cluster/n1.conf
+++ b/scripts/cluster/n1.conf
@@ -1,0 +1,16 @@
+port: 4223
+http_port: 8223
+server_name: n1
+
+jetstream {
+  store_dir: "./scripts/cluster/data/n1"
+}
+
+cluster {
+  name: failover_test
+  listen: 127.0.0.1:6223
+  routes: [
+    nats-route://127.0.0.1:6224
+    nats-route://127.0.0.1:6225
+  ]
+}

--- a/scripts/cluster/n2.conf
+++ b/scripts/cluster/n2.conf
@@ -1,0 +1,16 @@
+port: 4224
+http_port: 8224
+server_name: n2
+
+jetstream {
+  store_dir: "./scripts/cluster/data/n2"
+}
+
+cluster {
+  name: failover_test
+  listen: 127.0.0.1:6224
+  routes: [
+    nats-route://127.0.0.1:6223
+    nats-route://127.0.0.1:6225
+  ]
+}

--- a/scripts/cluster/n3.conf
+++ b/scripts/cluster/n3.conf
@@ -1,0 +1,16 @@
+port: 4225
+http_port: 8225
+server_name: n3
+
+jetstream {
+  store_dir: "./scripts/cluster/data/n3"
+}
+
+cluster {
+  name: failover_test
+  listen: 127.0.0.1:6225
+  routes: [
+    nats-route://127.0.0.1:6223
+    nats-route://127.0.0.1:6224
+  ]
+}

--- a/test/jetstream/api/kv/entry_test.exs
+++ b/test/jetstream/api/kv/entry_test.exs
@@ -1,0 +1,107 @@
+defmodule Gnat.Jetstream.API.KV.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Gnat.Jetstream.API.KV.Entry
+
+  @bucket "my_bucket"
+  @reply_to "$JS.ACK.KV_my_bucket.consumer.1.42.7.1750928948439739269.3"
+
+  describe "from_message/2" do
+    test "parses a put message with no headers" do
+      message = %{topic: "$KV.my_bucket.some.key", body: "hello", reply_to: @reply_to}
+
+      assert {:ok, entry} = Entry.from_message(message, @bucket)
+
+      assert %Entry{
+               bucket: "my_bucket",
+               key: "some.key",
+               value: "hello",
+               operation: :put,
+               revision: 42,
+               delta: 3
+             } = entry
+
+      assert %DateTime{} = entry.created
+    end
+
+    test "parses a put message when headers are present but not KV-operation" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "bar",
+        headers: [{"some-other", "value"}]
+      }
+
+      assert {:ok, %Entry{operation: :put, key: "foo", value: "bar"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "parses a DEL message as :delete" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"kv-operation", "DEL"}]
+      }
+
+      assert {:ok, %Entry{operation: :delete, key: "foo", value: ""}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "parses a PURGE message as :purge" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"kv-operation", "PURGE"}]
+      }
+
+      assert {:ok, %Entry{operation: :purge, key: "foo"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "treats a nats-marker-reason tombstone as :delete" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"nats-marker-reason", "MaxAge"}]
+      }
+
+      assert {:ok, %Entry{operation: :delete, key: "foo"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "recovers keys that include dots" do
+      message = %{topic: "$KV.my_bucket.a.b.c", body: "v"}
+
+      assert {:ok, %Entry{key: "a.b.c"}} = Entry.from_message(message, @bucket)
+    end
+
+    test "leaves revision/created/delta nil when no reply_to is present" do
+      message = %{topic: "$KV.my_bucket.foo", body: "bar"}
+
+      assert {:ok, %Entry{revision: nil, created: nil, delta: nil}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore when the subject does not belong to the bucket" do
+      message = %{topic: "$KV.other_bucket.foo", body: "bar"}
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore for a 409 leadership-change status message" do
+      message = %{
+        topic: "_INBOX.foo",
+        body: "",
+        status: "409",
+        description: "Leadership Change"
+      }
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore for a 100 idle heartbeat with no description" do
+      message = %{topic: "_INBOX.foo", body: "", status: "100"}
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+  end
+end

--- a/test/jetstream/api/kv/watcher_test.exs
+++ b/test/jetstream/api/kv/watcher_test.exs
@@ -1,0 +1,70 @@
+defmodule Gnat.Jetstream.API.KV.WatcherTest do
+  use Gnat.Jetstream.ConnCase, min_server_version: "2.6.2"
+
+  alias Gnat.Jetstream.API.KV
+
+  @moduletag with_gnat: :gnat
+
+  describe "status messages" do
+    setup do
+      bucket = "WATCHER_STATUS_TEST"
+      {:ok, _} = KV.create_bucket(:gnat, bucket)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        :ok = KV.delete_bucket(pid, bucket)
+        Gnat.stop(pid)
+      end)
+
+      test_pid = self()
+
+      {:ok, watcher} =
+        KV.watch(:gnat, bucket, fn action, key, value ->
+          send(test_pid, {action, key, value})
+        end)
+
+      on_exit(fn ->
+        if Process.alive?(watcher), do: KV.unwatch(watcher)
+      end)
+
+      %{watcher: watcher}
+    end
+
+    test "409 status messages are dropped", %{watcher: watcher} do
+      send(
+        watcher,
+        {:msg, %{status: "409", description: "Leadership Change", body: "", topic: "ignored"}}
+      )
+
+      refute_receive {:key_added, _, _}, 100
+      refute_receive {:key_deleted, _, _}, 100
+      assert Process.alive?(watcher)
+    end
+
+    test "100 idle heartbeat (no reply_to) is dropped", %{watcher: watcher} do
+      send(watcher, {:msg, %{status: "100", body: "", topic: "ignored"}})
+
+      refute_receive {:key_added, _, _}, 100
+      assert Process.alive?(watcher)
+    end
+
+    test "100 flow-control message is answered with an empty publish", %{watcher: watcher} do
+      reply_to = "_WATCHER_TEST.fc.#{System.unique_integer([:positive])}"
+      {:ok, _sub} = Gnat.sub(:gnat, self(), reply_to)
+
+      send(
+        watcher,
+        {:msg,
+         %{
+           status: "100",
+           description: "FlowControl Request",
+           body: "",
+           reply_to: reply_to,
+           topic: "ignored"
+         }}
+      )
+
+      assert_receive {:msg, %{topic: ^reply_to, body: ""}}, 500
+    end
+  end
+end

--- a/test/pull_consumer/batch_test.exs
+++ b/test/pull_consumer/batch_test.exs
@@ -301,31 +301,26 @@ defmodule Gnat.Jetstream.PullConsumer.BatchTest do
       assert_receive {:handled, 5, "e"}, 10_000
     end
 
-    test "batch_size 1 uses single-message mode (backward compatibility)" do
+    test "batch_size 1 uses single-message mode (sends +NXT on ack)" do
+      consumer_name = "BATCH_COMPAT_CONSUMER"
+
       consumer = %Consumer{
         stream_name: @stream_name,
-        durable_name: "BATCH_COMPAT_CONSUMER"
+        durable_name: consumer_name,
+        inactive_threshold: 30_000_000_000,
+        ack_policy: :explicit
       }
 
-      {:ok, _} = Consumer.create(:gnat, consumer)
+      # Subscribe to the ack subject to verify +NXT is sent (single-message pipeline)
+      # rather than an empty body (batch-mode ack).
+      {:ok, _} = Gnat.sub(:gnat, self(), "$JS.ACK.#{@stream_name}.#{consumer_name}.>")
 
-      # With batch_size: 1, should use ack_next (single-message pipeline)
-      # Subscribe to the ack subject to verify +NXT is sent (not batch ack)
-      Gnat.sub(:gnat, self(), "$JS.ACK.#{@stream_name}.BATCH_COMPAT_CONSUMER.>")
+      :ok = Gnat.pub(:gnat, "batch_test.compat", "compat-1")
 
-      start_supervised!(
-        {BatchPullConsumer,
-         consumer: %Consumer{
-           stream_name: @stream_name,
-           durable_name: "BATCH_COMPAT_COMPAT",
-           inactive_threshold: 30_000_000_000
-         },
-         batch_size: 1,
-         test_pid: self()}
-      )
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 1, test_pid: self()})
 
-      # batch_size: 1 doesn't enter batch code path, so we use the durable approach
-      # to verify the message is processed in single-message mode
+      assert_receive {:handled, 1, "compat-1"}, 5_000
+      assert_receive {:msg, %{body: "+NXT"}}, 5_000
     end
 
     test "batch mode with batch_size 2 and odd number of messages" do

--- a/test/pull_consumer/batch_test.exs
+++ b/test/pull_consumer/batch_test.exs
@@ -1,0 +1,489 @@
+defmodule Gnat.Jetstream.PullConsumer.BatchTest do
+  use Gnat.Jetstream.ConnCase
+
+  alias Gnat.Jetstream.API.{Consumer, Stream}
+
+  @stream_name "BATCH_TEST_STREAM"
+  @subject "batch_test.*"
+
+  defmodule BatchPullConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      batch_size = Keyword.fetch!(opts, :batch_size)
+
+      connection_opts =
+        [connection_name: :gnat, batch_size: batch_size, request_expires: 500_000_000]
+        |> maybe_put(:consumer, opts)
+        |> maybe_put(:stream_name, opts)
+        |> maybe_put(:consumer_name, opts)
+        |> maybe_put(:connection_retry_timeout, opts)
+        |> maybe_put(:connection_retries, opts)
+
+      state = %{
+        test_pid: Keyword.fetch!(opts, :test_pid),
+        messages: [],
+        call_count: 0
+      }
+
+      {:ok, state, connection_opts}
+    end
+
+    defp maybe_put(conn_opts, key, opts) do
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> Keyword.put(conn_opts, key, value)
+        :error -> conn_opts
+      end
+    end
+
+    @impl true
+    def handle_connected(consumer_info, state) do
+      send(state.test_pid, {:connected, consumer_info})
+      {:ok, state}
+    end
+
+    @impl true
+    def handle_message(message, state) do
+      call_count = state.call_count + 1
+      messages = [message.body | state.messages]
+      send(state.test_pid, {:handled, call_count, message.body})
+      {:ack, %{state | messages: messages, call_count: call_count}}
+    end
+  end
+
+  # A consumer whose handle_message returns :nack or :term based on message body
+  defmodule NonAckBatchConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      consumer = Keyword.fetch!(opts, :consumer)
+      batch_size = Keyword.fetch!(opts, :batch_size)
+
+      connection_opts = [
+        connection_name: :gnat,
+        consumer: consumer,
+        batch_size: batch_size
+      ]
+
+      state = %{test_pid: Keyword.fetch!(opts, :test_pid)}
+      {:ok, state, connection_opts}
+    end
+
+    @impl true
+    def handle_message(%{body: "nack_me"}, state) do
+      send(state.test_pid, {:returned_nack})
+      {:nack, state}
+    end
+
+    def handle_message(%{body: "term_me"}, state) do
+      send(state.test_pid, {:returned_term})
+      {:term, state}
+    end
+
+    def handle_message(message, state) do
+      send(state.test_pid, {:handled, message.body})
+      {:ack, state}
+    end
+  end
+
+  describe "batch mode" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream = %Stream{name: @stream_name, subjects: [@subject]}
+      {:ok, _} = Stream.create(:gnat, stream)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        Stream.delete(pid, @stream_name)
+        Gnat.stop(pid)
+      end)
+
+      :ok
+    end
+
+    test "processes a full batch of messages" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # Publish exactly batch_size messages before starting consumer
+      for i <- 1..3 do
+        :ok = Gnat.pub(:gnat, "batch_test.full", "msg-#{i}")
+      end
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 3, test_pid: self()})
+
+      assert_receive {:connected, _consumer_info}
+
+      # All 3 messages should be delivered individually to handle_message
+      assert_receive {:handled, 1, "msg-1"}
+      assert_receive {:handled, 2, "msg-2"}
+      assert_receive {:handled, 3, "msg-3"}
+    end
+
+    test "processes partial batch when fewer messages than batch_size" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # Only 2 messages with batch_size of 5
+      :ok = Gnat.pub(:gnat, "batch_test.partial", "partial-1")
+      :ok = Gnat.pub(:gnat, "batch_test.partial", "partial-2")
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 5, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      # Partial batch should still be processed when terminal signal arrives
+      assert_receive {:handled, 1, "partial-1"}, 3_000
+      assert_receive {:handled, 2, "partial-2"}, 3_000
+    end
+
+    test "empty stream does not hang the consumer" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      pid =
+        start_supervised!(
+          {BatchPullConsumer, consumer: consumer, batch_size: 5, test_pid: self()}
+        )
+
+      assert_receive {:connected, consumer_info}
+      assert consumer_info.num_pending == 0
+
+      # Consumer should not hang — it should be alive and responsive
+      assert Process.alive?(pid)
+
+      # Now publish a message — consumer should still pick it up
+      :ok = Gnat.pub(:gnat, "batch_test.empty", "late-arrival")
+
+      # In batch mode with batch_size 5, a single message will arrive as a
+      # partial batch (terminal signal triggers processing of the 1-message buffer)
+      assert_receive {:handled, 1, "late-arrival"}, 10_000
+    end
+
+    test "continues processing after multiple batches" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # Publish 6 messages with batch_size 3 — should produce 2 full batches
+      for i <- 1..6 do
+        :ok = Gnat.pub(:gnat, "batch_test.multi", "multi-#{i}")
+      end
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 3, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      # All 6 messages processed across 2 batches
+      for i <- 1..6 do
+        assert_receive {:handled, ^i, _body}, 5_000
+      end
+    end
+
+    test "handles messages arriving after initial catch-up" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # Start with some messages to catch up on
+      for i <- 1..3 do
+        :ok = Gnat.pub(:gnat, "batch_test.live", "catchup-#{i}")
+      end
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 3, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      # Wait for catch-up batch
+      for i <- 1..3 do
+        assert_receive {:handled, ^i, _body}, 5_000
+      end
+
+      # Now publish new messages — consumer should transition to tailing mode
+      # and still pick these up
+      :ok = Gnat.pub(:gnat, "batch_test.live", "live-1")
+      :ok = Gnat.pub(:gnat, "batch_test.live", "live-2")
+
+      assert_receive {:handled, 4, "live-1"}, 10_000
+      assert_receive {:handled, 5, "live-2"}, 10_000
+    end
+
+    test "nack and term returns are treated as ack with warning logged" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      :ok = Gnat.pub(:gnat, "batch_test.nonack", "normal")
+      :ok = Gnat.pub(:gnat, "batch_test.nonack", "nack_me")
+      :ok = Gnat.pub(:gnat, "batch_test.nonack", "term_me")
+
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          start_supervised!(
+            {NonAckBatchConsumer, consumer: consumer, batch_size: 3, test_pid: self()}
+          )
+
+          assert_receive {:handled, "normal"}, 5_000
+          assert_receive {:returned_nack}, 5_000
+          assert_receive {:returned_term}, 5_000
+
+          # Give time for the log to flush
+          Process.sleep(100)
+        end)
+
+      # The warning should mention that batch mode doesn't support nack/term
+      assert log =~ "batch mode does not support"
+    end
+
+    test "consumer does not get stuck after processing batch" do
+      # This test verifies the critical flow: after a batch is processed and acked,
+      # the consumer must issue another fetch request. If it doesn't, messages
+      # published after the batch will never arrive.
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 2, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      # First batch
+      :ok = Gnat.pub(:gnat, "batch_test.stuck", "a")
+      :ok = Gnat.pub(:gnat, "batch_test.stuck", "b")
+
+      assert_receive {:handled, 1, "a"}, 10_000
+      assert_receive {:handled, 2, "b"}, 10_000
+
+      # Wait a moment, then send another batch — consumer must not be stuck
+      Process.sleep(200)
+
+      :ok = Gnat.pub(:gnat, "batch_test.stuck", "c")
+      :ok = Gnat.pub(:gnat, "batch_test.stuck", "d")
+
+      assert_receive {:handled, 3, "c"}, 10_000
+      assert_receive {:handled, 4, "d"}, 10_000
+
+      # Third batch to confirm sustained flow
+      Process.sleep(200)
+
+      :ok = Gnat.pub(:gnat, "batch_test.stuck", "e")
+
+      assert_receive {:handled, 5, "e"}, 10_000
+    end
+
+    test "batch_size 1 uses single-message mode (backward compatibility)" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        durable_name: "BATCH_COMPAT_CONSUMER"
+      }
+
+      {:ok, _} = Consumer.create(:gnat, consumer)
+
+      # With batch_size: 1, should use ack_next (single-message pipeline)
+      # Subscribe to the ack subject to verify +NXT is sent (not batch ack)
+      Gnat.sub(:gnat, self(), "$JS.ACK.#{@stream_name}.BATCH_COMPAT_CONSUMER.>")
+
+      start_supervised!(
+        {BatchPullConsumer,
+         consumer: %Consumer{
+           stream_name: @stream_name,
+           durable_name: "BATCH_COMPAT_COMPAT",
+           inactive_threshold: 30_000_000_000
+         },
+         batch_size: 1,
+         test_pid: self()}
+      )
+
+      # batch_size: 1 doesn't enter batch code path, so we use the durable approach
+      # to verify the message is processed in single-message mode
+    end
+
+    test "batch mode with batch_size 2 and odd number of messages" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # 5 messages with batch_size 2: batches of [2, 2, 1(partial)]
+      for i <- 1..5 do
+        :ok = Gnat.pub(:gnat, "batch_test.odd", "odd-#{i}")
+      end
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 2, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      for i <- 1..5 do
+        assert_receive {:handled, ^i, _body}, 5_000
+      end
+    end
+
+    test "large batch processes many messages correctly" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      msg_count = 50
+
+      for i <- 1..msg_count do
+        :ok = Gnat.pub(:gnat, "batch_test.large", "large-#{i}")
+      end
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 10, test_pid: self()})
+
+      assert_receive {:connected, _}
+
+      # All 50 messages should be delivered (5 batches of 10)
+      for i <- 1..msg_count do
+        assert_receive {:handled, ^i, _body}, 10_000
+      end
+    end
+
+    test "can be closed cleanly during batch mode" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      pid =
+        start_supervised!(
+          {BatchPullConsumer, consumer: consumer, batch_size: 5, test_pid: self()}
+        )
+
+      assert_receive {:connected, _}
+
+      ref = Process.monitor(pid)
+      assert :ok = Gnat.Jetstream.PullConsumer.close(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}
+    end
+
+    test "handle_connected receives consumer info in batch mode" do
+      # Publish messages before consumer starts, so num_pending > 0
+      for i <- 1..3 do
+        {:ok, _} = Gnat.request(:gnat, "batch_test.connected", "pre-#{i}")
+      end
+
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      start_supervised!({BatchPullConsumer, consumer: consumer, batch_size: 5, test_pid: self()})
+
+      assert_receive {:connected, consumer_info}
+      assert consumer_info.num_pending == 3
+    end
+
+    test "rejects ephemeral consumer with ack_policy :explicit and batch_size > 1" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :explicit,
+        deliver_policy: :all
+      }
+
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{message: message}, _}} =
+               BatchPullConsumer.start_link(consumer: consumer, batch_size: 3, test_pid: self())
+
+      assert message =~ "batch_size > 1 requires ack_policy: :all"
+    end
+
+    test "rejects ephemeral consumer with default ack_policy and batch_size > 1" do
+      # Consumer defaults to ack_policy: :explicit, so forgetting to set it should fail
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        deliver_policy: :all
+      }
+
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{message: message}, _}} =
+               BatchPullConsumer.start_link(consumer: consumer, batch_size: 3, test_pid: self())
+
+      assert message =~ "batch_size > 1 requires ack_policy: :all"
+    end
+
+    test "durable consumer with ack_policy :explicit fails to connect in batch mode" do
+      # Create a durable consumer with explicit ack policy
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        durable_name: "BATCH_EXPLICIT_CONSUMER",
+        ack_policy: :explicit
+      }
+
+      {:ok, _} = Consumer.create(:gnat, consumer)
+
+      pid =
+        start_supervised!(
+          {BatchPullConsumer,
+           [
+             stream_name: @stream_name,
+             consumer_name: "BATCH_EXPLICIT_CONSUMER",
+             batch_size: 3,
+             test_pid: self(),
+             connection_retry_timeout: 50,
+             connection_retries: 1
+           ]},
+          restart: :temporary
+        )
+
+      ref = Process.monitor(pid)
+
+      # Should fail to connect and eventually stop after retries
+      assert_receive {:DOWN, ^ref, :process, ^pid, :timeout}, 5_000
+    end
+
+    test "allows batch_size 1 with any ack_policy (no validation needed)" do
+      consumer = %Consumer{
+        stream_name: @stream_name,
+        ack_policy: :explicit,
+        deliver_policy: :all
+      }
+
+      # batch_size: 1 should not trigger the ack_policy validation
+      pid =
+        start_supervised!(
+          {BatchPullConsumer, consumer: consumer, batch_size: 1, test_pid: self()}
+        )
+
+      assert_receive {:connected, _}
+      assert Process.alive?(pid)
+    end
+  end
+end

--- a/test/pull_consumer/ephemeral_test.exs
+++ b/test/pull_consumer/ephemeral_test.exs
@@ -24,6 +24,12 @@ defmodule Gnat.Jetstream.PullConsumer.EphemeralTest do
     end
 
     @impl true
+    def handle_connected(consumer_info, state) do
+      send(state.test_pid, {:connected, consumer_info})
+      {:ok, state}
+    end
+
+    @impl true
     def handle_message(message, state) do
       send(state.test_pid, {:pulled, message})
       {:ack, state}
@@ -57,6 +63,9 @@ defmodule Gnat.Jetstream.PullConsumer.EphemeralTest do
       {:ok, _resp} = Gnat.request(:gnat, "stream_2.ohai", "whatsup")
 
       start_supervised!({ExamplePullConsumer, consumer: consumer, test_pid: self()})
+
+      assert_receive {:connected, consumer_info}
+      assert consumer_info.num_pending == 1
 
       assert_receive {:pulled, message}
       assert %{topic: "stream_2.ohai", body: "whatsup"} = message

--- a/test/pull_consumer/status_messages_test.exs
+++ b/test/pull_consumer/status_messages_test.exs
@@ -162,6 +162,12 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
         send(state.test_pid, {:handled, message.body})
         {:ack, state}
       end
+
+      @impl true
+      def handle_status(message, state) do
+        send(state.test_pid, {:status, message})
+        {:ok, state}
+      end
     end
 
     test "batch mode issues a new pull after 409 with empty buffer",
@@ -190,6 +196,8 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
 
       # A new pull must be issued or the consumer is stuck.
       assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+      # And handle_status should have observed the 409.
+      assert_receive {:status, %{status: "409", description: "Leadership Change"}}, 1_000
     end
 
     test "batch mode processes partial buffer and re-pulls on 409",
@@ -231,6 +239,7 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
 
       assert_receive {:handled, "partial-1"}, 1_000
       assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+      assert_receive {:status, %{status: "409", description: "Leadership Change"}}, 1_000
     end
 
     test "batch mode treats 100 heartbeat as a no-op (no re-pull)",
@@ -254,6 +263,8 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
       send(pid, {:msg, %{status: "100", body: "", gnat: :gnat}})
 
       refute_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 200
+      # But handle_status should still be invoked so users can observe heartbeats.
+      assert_receive {:status, %{status: "100"}}, 500
     end
   end
 

--- a/test/pull_consumer/status_messages_test.exs
+++ b/test/pull_consumer/status_messages_test.exs
@@ -13,9 +13,9 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
     @impl true
     def init(opts) do
       {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+      state = Keyword.merge([connection_name: :gnat], opts)
 
-      {:ok, %{test_pid: test_pid},
-       Keyword.merge([connection_name: :gnat], opts)}
+      {:ok, %{test_pid: test_pid}, state}
     end
 
     @impl true

--- a/test/pull_consumer/status_messages_test.exs
+++ b/test/pull_consumer/status_messages_test.exs
@@ -101,5 +101,167 @@ defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
       assert_receive {:handle_status, %{status: "409", description: "Leadership Change"}}
       refute_receive {:handle_message, _}, 100
     end
+
+    test "single-message mode issues a new pull after a 409",
+         %{stream_name: stream_name, consumer_name: consumer_name} do
+      # Subscribe to the next-message subject to observe outbound pulls.
+      {:ok, _sid} =
+        Gnat.sub(:gnat, self(), "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.#{consumer_name}")
+
+      pid =
+        start_supervised!(
+          {SilentConsumer,
+           test_pid: self(), stream_name: stream_name, consumer_name: consumer_name}
+        )
+
+      # Drain the initial pull issued on connect.
+      assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+
+      # A new pull must be issued or the consumer is stuck.
+      assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+    end
+  end
+
+  describe "batch-mode JetStream status messages" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream_name = "STATUS_BATCH_STREAM"
+      subject = "status.batch"
+
+      stream = %Stream{name: stream_name, subjects: [subject]}
+      {:ok, _} = Stream.create(:gnat, stream)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        :ok = Stream.delete(pid, stream_name)
+        Gnat.stop(pid)
+      end)
+
+      %{stream_name: stream_name, subject: subject}
+    end
+
+    defmodule BatchObservingConsumer do
+      use Gnat.Jetstream.PullConsumer
+
+      def start_link(opts) do
+        Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+      end
+
+      @impl true
+      def init(opts) do
+        {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+        state = Keyword.merge([connection_name: :gnat], opts)
+        {:ok, %{test_pid: test_pid}, state}
+      end
+
+      @impl true
+      def handle_message(message, state) do
+        send(state.test_pid, {:handled, message.body})
+        {:ack, state}
+      end
+    end
+
+    test "batch mode issues a new pull after 409 with empty buffer",
+         %{stream_name: stream_name} do
+      consumer = %Gnat.Jetstream.API.Consumer{
+        stream_name: stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      # Subscribe to the next-message subject before starting the consumer so
+      # we see the pull the consumer issues at connect time and any re-pulls.
+      {:ok, _sid} = Gnat.sub(:gnat, self(), "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.>")
+
+      pid =
+        start_supervised!(
+          {BatchObservingConsumer, consumer: consumer, batch_size: 5, test_pid: self()}
+        )
+
+      # Drain pulls issued during connect (at minimum the initial catch-up fetch).
+      # Absorb any that arrive within a short window so the assert below only
+      # fires on the post-409 re-pull.
+      drain_pulls(200)
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+
+      # A new pull must be issued or the consumer is stuck.
+      assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+    end
+
+    test "batch mode processes partial buffer and re-pulls on 409",
+         %{stream_name: stream_name, subject: subject} do
+      consumer = %Gnat.Jetstream.API.Consumer{
+        stream_name: stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      {:ok, _sid} = Gnat.sub(:gnat, self(), "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.>")
+
+      # Publish a single message so the consumer buffers 1 of a 5-message batch.
+      :ok = Gnat.pub(:gnat, subject, "buffered-1")
+
+      pid =
+        start_supervised!(
+          {BatchObservingConsumer, consumer: consumer, batch_size: 5, test_pid: self()}
+        )
+
+      # The buffered message should arrive at the server-issued 404 terminator
+      # and be processed. Once that's settled, drain any further pulls.
+      assert_receive {:handled, "buffered-1"}, 5_000
+      drain_pulls(200)
+
+      # Now stuff a new message into the buffer via direct send and inject a 409.
+      fake_msg = %{
+        topic: subject,
+        body: "partial-1",
+        reply_to: "$JS.ACK.#{stream_name}.FAKE.1.1.1.0.0",
+        gnat: :gnat
+      }
+
+      send(pid, {:msg, fake_msg})
+
+      # A 409 should cause the partial buffer to be processed (handle_message
+      # called for "partial-1") and a fresh pull to be issued.
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+
+      assert_receive {:handled, "partial-1"}, 1_000
+      assert_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 1_000
+    end
+
+    test "batch mode treats 100 heartbeat as a no-op (no re-pull)",
+         %{stream_name: stream_name} do
+      consumer = %Gnat.Jetstream.API.Consumer{
+        stream_name: stream_name,
+        ack_policy: :all,
+        deliver_policy: :all
+      }
+
+      {:ok, _sid} = Gnat.sub(:gnat, self(), "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.>")
+
+      pid =
+        start_supervised!(
+          {BatchObservingConsumer, consumer: consumer, batch_size: 5, test_pid: self()}
+        )
+
+      drain_pulls(200)
+
+      # 100 is a keep-alive on the existing pull — must NOT cause a re-pull.
+      send(pid, {:msg, %{status: "100", body: "", gnat: :gnat}})
+
+      refute_receive {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}}, 200
+    end
+  end
+
+  defp drain_pulls(timeout) do
+    receive do
+      {:msg, %{topic: "$JS.API.CONSUMER.MSG.NEXT." <> _}} -> drain_pulls(timeout)
+    after
+      timeout -> :ok
+    end
   end
 end

--- a/test/pull_consumer/status_messages_test.exs
+++ b/test/pull_consumer/status_messages_test.exs
@@ -1,0 +1,105 @@
+defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
+  use Gnat.Jetstream.ConnCase
+
+  alias Gnat.Jetstream.API.{Consumer, Stream}
+
+  defmodule ObservingConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+
+      {:ok, %{test_pid: test_pid},
+       Keyword.merge([connection_name: :gnat], opts)}
+    end
+
+    @impl true
+    def handle_message(message, state) do
+      send(state.test_pid, {:handle_message, message})
+      {:ack, state}
+    end
+
+    @impl true
+    def handle_status(message, state) do
+      send(state.test_pid, {:handle_status, message})
+      {:ok, state}
+    end
+  end
+
+  defmodule SilentConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+
+      {:ok, test_pid, Keyword.merge([connection_name: :gnat], opts)}
+    end
+
+    @impl true
+    def handle_message(message, test_pid) do
+      send(test_pid, {:handle_message, message})
+      {:ack, test_pid}
+    end
+  end
+
+  describe "JetStream status messages" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream_name = "STATUS_TEST_STREAM"
+      consumer_name = "STATUS_TEST_CONSUMER"
+
+      stream = %Stream{name: stream_name, subjects: ["status.test"]}
+      {:ok, _} = Stream.create(:gnat, stream)
+
+      consumer = %Consumer{stream_name: stream_name, durable_name: consumer_name}
+      {:ok, _} = Consumer.create(:gnat, consumer)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        :ok = Stream.delete(pid, stream_name)
+        Gnat.stop(pid)
+      end)
+
+      %{stream_name: stream_name, consumer_name: consumer_name}
+    end
+
+    test "are not forwarded to handle_message when no handle_status is defined",
+         %{stream_name: stream_name, consumer_name: consumer_name} do
+      pid =
+        start_supervised!(
+          {SilentConsumer,
+           test_pid: self(), stream_name: stream_name, consumer_name: consumer_name}
+        )
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+      send(pid, {:msg, %{status: "100", body: "", gnat: :gnat}})
+
+      refute_receive {:handle_message, _}, 100
+    end
+
+    test "are forwarded to handle_status when the callback is defined",
+         %{stream_name: stream_name, consumer_name: consumer_name} do
+      pid =
+        start_supervised!(
+          {ObservingConsumer,
+           test_pid: self(), stream_name: stream_name, consumer_name: consumer_name}
+        )
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+
+      assert_receive {:handle_status, %{status: "409", description: "Leadership Change"}}
+      refute_receive {:handle_message, _}, 100
+    end
+  end
+end


### PR DESCRIPTION
There are a few potential changes that I want to test incorporate into this library and I'll use this branch during development and cut a few RC versions from here before merging to main and doing a full release.

Key Changes:
* PullConsumer `handle_connected` callback provides a change to check the state of the consumer before receiving messages
* PullConsumer `batch_size` option which works with `ack_policy: :all` to provide high throughput and efficiency in cases where you don't need acknowledgement/rejection for each individual message
* Fix 2 Pager bugs
  * There was a typo when checking the `:domain` option passed by the user
  * Don't raise an exception if `Consumer.delete` fails we're already registering an ephemeral consumer with 30sec cleanup period. We'll always attempt to cleanup the consumer eagerly, but there are race conditions where a temporary consumer won't instantly confirm deletion and we don't want these to interrupt the user's flow
* Add `handle_status` optional callback to PullConsumer
  * Skip status messages being handled by 
* Add `KV.Entry` module with public interface to parse KV messages
* Add FlowControl to `KV.Watcher` to follow community conventions