### PR TITLE
add KV.Entry helper and handle_status/2 callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.14
+
+* Add `Gnat.Jetstream.API.KV.Entry` with `from_message/2` for parsing a raw
+  NATS message from a KV bucket's underlying stream into a structured entry
+  (operation, key, value, revision, created, delta). Intended to be shared
+  between the built-in `KV.Watcher` and user-supplied `PullConsumer`
+  implementations (e.g. caches that need to detect when they are caught up
+  with the stream). Returns `:ignore` for messages that are not KV records.
+* `KV.Watcher` now uses `KV.Entry` internally; its public callback API is
+  unchanged.
+* **Behavior change (bugfix):** `PullConsumer` no longer forwards JetStream
+  informational status messages (e.g. `100` idle heartbeat, `409` leadership
+  change) to `c:handle_message/2`. These are not stream records and cannot
+  be acked. In single-message mode the consumer now drops them and re-issues
+  a pull request.
+* Add an optional `c:handle_status/2` callback to `Gnat.Jetstream.PullConsumer`
+  for users who want to observe status messages (e.g. log on `409`).
+
 ## 1.11
 
 * Allow clients to force authentication without server auth_required by @mmmries in #205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   implementations (e.g. caches that need to detect when they are caught up
   with the stream). Returns `:ignore` for messages that are not KV records.
 * `KV.Watcher` now uses `KV.Entry` internally; its public callback API is
-  unchanged.
+  unchanged. The push consumer it creates now enables server-driven flow
+  control and a 5s idle heartbeat (matching nats.go's ordered-consumer
+  defaults), so slow handlers apply backpressure instead of being dropped
+  as slow consumers.
 * **Behavior change (bugfix):** `PullConsumer` no longer forwards JetStream
   informational status messages (e.g. `100` idle heartbeat, `409` leadership
   change) to `c:handle_message/2`. These are not stream records and cannot

--- a/lib/gnat/jetstream/api/kv.ex
+++ b/lib/gnat/jetstream/api/kv.ex
@@ -3,6 +3,15 @@ defmodule Gnat.Jetstream.API.KV do
   API for interacting with the Key/Value store functionality in Nats Jetstream.
 
   Learn about the Key/Value store: https://docs.nats.io/nats-concepts/jetstream/key-value-store
+
+  ## Consuming KV changes from a custom PullConsumer
+
+  `watch/3` covers the common "push consumer" use case for reacting to bucket
+  changes. If you need a pull-based consumer instead (e.g. to hydrate a local
+  cache and detect when it is caught up with the stream), see
+  `Gnat.Jetstream.API.KV.Entry` for a shared helper that parses a raw NATS
+  message into a KV operation/key/value triple with optional revision
+  metadata.
   """
   alias Gnat.Jetstream.API.{Stream}
 

--- a/lib/gnat/jetstream/api/kv/entry.ex
+++ b/lib/gnat/jetstream/api/kv/entry.ex
@@ -1,0 +1,149 @@
+defmodule Gnat.Jetstream.API.KV.Entry do
+  @moduledoc """
+  A parsed view of a single message from a Key/Value bucket's underlying stream.
+
+  Messages delivered from a KV bucket's stream encode three different operations
+  (put, delete, purge) using a combination of the `kv-operation` header, the
+  `nats-marker-reason` header, and the absence of any headers. Recovering the
+  original key also requires stripping the `$KV.<bucket>.` subject prefix.
+
+  This module captures that convention in one place so both the built-in
+  `Gnat.Jetstream.API.KV.Watcher` (push consumer) and user-supplied
+  `Gnat.Jetstream.PullConsumer` implementations can share it.
+
+  ## Using with a custom PullConsumer
+
+  A common use case is hydrating a local cache from a KV bucket by driving a
+  `Gnat.Jetstream.PullConsumer`. Inside `c:handle_message/2`, convert the raw
+  message into an `Entry` and branch on the operation:
+
+      defmodule MyApp.KVCache do
+        use Gnat.Jetstream.PullConsumer
+
+        alias Gnat.Jetstream.API.KV
+
+        @bucket "my_bucket"
+
+        @impl true
+        def handle_message(message, state) do
+          case KV.Entry.from_message(message, @bucket) do
+            {:ok, %KV.Entry{operation: :put, key: key, value: value}} ->
+              {:ack, put_in(state.cache[key], value)}
+
+            {:ok, %KV.Entry{operation: op, key: key}} when op in [:delete, :purge] ->
+              {:ack, update_in(state.cache, &Map.delete(&1, key))}
+
+            :ignore ->
+              {:ack, state}
+          end
+        end
+      end
+
+  The returned struct also carries the JetStream `revision` (stream sequence),
+  `created` timestamp, and `delta` (`num_pending`) when the message includes
+  JetStream metadata, which is useful for detecting when the consumer has
+  caught up with the tail of the stream (`delta == 0`).
+
+  ## Messages that are not KV records
+
+  `from_message/2` returns `:ignore` when the input is not a KV record — for
+  example a JetStream status message (`100` heartbeat, `404`/`408` pull
+  terminator, `409` leadership change) or a message whose subject does not
+  belong to the given bucket. In normal operation the `Watcher` and
+  `PullConsumer` layers filter status messages out before they reach user
+  code, so this is a defensive fallback rather than something consumers are
+  expected to rely on.
+  """
+
+  alias Gnat.Jetstream.API.Message
+
+  @operation_header "kv-operation"
+  @operation_del "DEL"
+  @operation_purge "PURGE"
+  @nats_marker_reason_header "nats-marker-reason"
+  @subject_prefix "$KV."
+
+  @type operation :: :put | :delete | :purge
+
+  @type t :: %__MODULE__{
+          bucket: String.t(),
+          key: String.t(),
+          value: binary(),
+          operation: operation(),
+          revision: non_neg_integer() | nil,
+          created: DateTime.t() | nil,
+          delta: non_neg_integer() | nil
+        }
+
+  defstruct [:bucket, :key, :value, :operation, :revision, :created, :delta]
+
+  @doc """
+  Parse a NATS message delivered from a KV bucket's underlying stream into an
+  `Entry`.
+
+  `bucket_name` must match the bucket the message was published to; it is used
+  to strip the `$KV.<bucket>.` subject prefix and recover the key.
+
+  Returns `:ignore` if the message is not a KV record for the given bucket
+  (JetStream status message, wrong subject, etc.).
+
+  The `:revision`, `:created`, and `:delta` fields are populated when the
+  message carries a JetStream `$JS.ACK...` reply subject. For messages without
+  one (e.g. direct get responses), those fields are `nil`.
+  """
+  @spec from_message(Gnat.message(), bucket_name :: String.t()) :: {:ok, t()} | :ignore
+  def from_message(message, bucket_name) do
+    with false <- status_message?(message),
+         {:ok, key} <- extract_key(message, bucket_name) do
+      entry = %__MODULE__{
+        bucket: bucket_name,
+        key: key,
+        value: Map.get(message, :body, ""),
+        operation: operation(message)
+      }
+
+      {:ok, apply_metadata(entry, message)}
+    else
+      _ -> :ignore
+    end
+  end
+
+  defp status_message?(%{status: status}) when is_binary(status) and status != "", do: true
+  defp status_message?(_), do: false
+
+  defp extract_key(%{topic: topic}, bucket_name) do
+    prefix = @subject_prefix <> bucket_name <> "."
+
+    if String.starts_with?(topic, prefix) do
+      {:ok, binary_part(topic, byte_size(prefix), byte_size(topic) - byte_size(prefix))}
+    else
+      :error
+    end
+  end
+
+  defp operation(%{headers: headers}) when is_list(headers) do
+    Enum.find_value(headers, :put, fn
+      {@operation_header, @operation_del} -> :delete
+      {@operation_header, @operation_purge} -> :purge
+      {@nats_marker_reason_header, _} -> :delete
+      _ -> false
+    end)
+  end
+
+  defp operation(_message), do: :put
+
+  defp apply_metadata(entry, message) do
+    case Message.metadata(message) do
+      {:ok, metadata} ->
+        %__MODULE__{
+          entry
+          | revision: metadata.stream_seq,
+            created: metadata.timestamp,
+            delta: metadata.num_pending
+        }
+
+      {:error, _} ->
+        entry
+    end
+  end
+end

--- a/lib/gnat/jetstream/api/kv/watcher.ex
+++ b/lib/gnat/jetstream/api/kv/watcher.ex
@@ -11,6 +11,12 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
   alias Gnat.Jetstream.API.{Consumer, KV, Util}
   alias Gnat.Jetstream.API.KV.Entry
 
+  # Matches the ordered-consumer defaults used by the nats.go KV watcher:
+  # a 5s idle heartbeat and server-driven flow control. The flow-control
+  # messages arrive as 100-status messages with a reply subject — the client
+  # is expected to publish an empty reply so the server releases backpressure.
+  @flow_control_heartbeat_ns 5_000_000_000
+
   @type keywatch_handler ::
           (action :: :key_deleted | :key_added, key :: String.t(), value :: any() -> nil)
 
@@ -48,6 +54,23 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
     :ok = Consumer.delete(state.conn, stream, state.consumer_name, state.domain)
   end
 
+  # Flow-control request: the server is asking us to acknowledge that we're
+  # keeping up. Responding releases backpressure so the server continues
+  # delivering messages to slow handlers rather than dropping us as a slow
+  # consumer.
+  def handle_info({:msg, %{status: "100", reply_to: reply_to}}, state)
+      when is_binary(reply_to) and reply_to != "" do
+    :ok = Gnat.pub(state.conn, reply_to, "")
+    {:noreply, state}
+  end
+
+  # Idle heartbeat (status 100 with no reply_to) and any other informational
+  # status message (404, 408, 409, etc.) — not a stream record, drop it.
+  def handle_info({:msg, %{status: status}}, state)
+      when is_binary(status) and status != "" do
+    {:noreply, state}
+  end
+
   def handle_info({:msg, message}, state) do
     case Entry.from_message(message, state.bucket_name) do
       {:ok, entry} ->
@@ -77,7 +100,9 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
              stream_name: stream,
              ack_policy: :none,
              max_ack_pending: -1,
-             max_deliver: 1
+             max_deliver: 1,
+             flow_control: true,
+             idle_heartbeat: @flow_control_heartbeat_ns
            }) do
       {:ok, {sub, consumer_name}}
     end

--- a/lib/gnat/jetstream/api/kv/watcher.ex
+++ b/lib/gnat/jetstream/api/kv/watcher.ex
@@ -9,11 +9,7 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
   use GenServer
 
   alias Gnat.Jetstream.API.{Consumer, KV, Util}
-
-  @operation_header "kv-operation"
-  @operation_del "DEL"
-  @operation_purge "PURGE"
-  @nats_marker_reason_header "nats-marker-reason"
+  alias Gnat.Jetstream.API.KV.Entry
 
   @type keywatch_handler ::
           (action :: :key_deleted | :key_added, key :: String.t(), value :: any() -> nil)
@@ -52,41 +48,21 @@ defmodule Gnat.Jetstream.API.KV.Watcher do
     :ok = Consumer.delete(state.conn, stream, state.consumer_name, state.domain)
   end
 
-  # Received from NATS when headers are on the message (delete)
-  def handle_info({:msg, %{topic: key, body: body, headers: headers}}, state) do
-    key = KV.subject_to_key(key, state.bucket_name)
+  def handle_info({:msg, message}, state) do
+    case Entry.from_message(message, state.bucket_name) do
+      {:ok, entry} ->
+        state.handler.(action(entry.operation), entry.key, entry.value)
 
-    notification =
-      Enum.find_value(headers, fn
-        {@operation_header, @operation_del} ->
-          :key_deleted
-
-        {@operation_header, @operation_purge} ->
-          :key_purged
-
-        {@nats_marker_reason_header, _} ->
-          :key_deleted
-
-        _ ->
-          false
-      end)
-
-    if notification do
-      state.handler.(notification, key, body)
-    else
-      state.handler.(:key_added, key, body)
+      :ignore ->
+        :ok
     end
 
     {:noreply, state}
   end
 
-  # Received from NATS with no headers (add)
-  def handle_info({:msg, %{topic: key, body: body}}, state) do
-    key = KV.subject_to_key(key, state.bucket_name)
-
-    state.handler.(:key_added, key, body)
-    {:noreply, state}
-  end
+  defp action(:put), do: :key_added
+  defp action(:delete), do: :key_deleted
+  defp action(:purge), do: :key_purged
 
   defp subscribe(conn, bucket_name) do
     stream = KV.stream_name(bucket_name)

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -243,6 +243,11 @@ defmodule Gnat.Jetstream.PullConsumer do
   Invoked to synchronously process a message pulled by the consumer.
   Depending on the value it returns, the acknowledgement is or is not sent.
 
+  Only real stream messages reach this callback. JetStream informational
+  status messages (e.g. `100` heartbeat, `404`/`408` pull terminator, `409`
+  leadership change) are intercepted by the consumer and never passed here.
+  See `c:handle_status/2` if you want to observe them.
+
   ## ACK actions
 
   Possible ACK actions values explained:
@@ -302,7 +307,42 @@ defmodule Gnat.Jetstream.PullConsumer do
               state :: term()
             ) :: {:ok, new_state :: term()}
 
-  @optional_callbacks [handle_connected: 2]
+  @doc """
+  Invoked when the consumer receives an informational JetStream status message
+  instead of a real stream message.
+
+  JetStream delivers status messages on the same subscription as regular
+  messages — for example a `100` idle heartbeat, a `404`/`408` pull request
+  terminator, or a `409` leadership change. These are not stream records and
+  cannot be acked, so the PullConsumer never forwards them to `c:handle_message/2`.
+
+  By default they are silently dropped and the consumer continues fetching
+  the next message. Implement this callback if you want to observe them — for
+  example to log a warning on leadership changes, or to track heartbeat
+  arrival.
+
+  The callback receives the raw `Gnat.message()` (which includes `:status`
+  and optionally `:description`) and the current state. Returning
+  `{:ok, new_state}` updates the state; the consumer then proceeds the same
+  way it would have if the callback had not been defined.
+
+  This callback is optional.
+
+  ## Example
+
+      @impl true
+      def handle_status(%{status: "409", description: description}, state) do
+        Logger.warning("JetStream 409 from consumer: #\{description}")
+        {:ok, state}
+      end
+
+      def handle_status(_message, state), do: {:ok, state}
+
+  """
+  @callback handle_status(message :: Gnat.message(), state :: term()) ::
+              {:ok, new_state :: term()}
+
+  @optional_callbacks [handle_connected: 2, handle_status: 2]
 
   @typedoc """
   The pull consumer reference.

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -236,6 +236,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
+  defp maybe_handle_status(message, %__MODULE__{module: module, state: state} = gen_state) do
+    if function_exported?(module, :handle_status, 2) do
+      {:ok, new_state} = module.handle_status(message, state)
+      %{gen_state | state: new_state}
+    else
+      gen_state
+    end
+  end
+
   defp connection_pid(connection_name) when is_pid(connection_name) do
     if Process.alive?(connection_name) do
       {:ok, connection_name}
@@ -274,6 +283,46 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         request_batch(gnat, gen_state, :catching_up)
         {:noreply, gen_state}
     end
+  end
+
+  # -- Batch mode: non-terminator informational status (e.g. 100 heartbeat, 409
+  # leadership change). Drop it — these aren't stream records and can't be
+  # acked. The batch continues waiting for real messages or a 404/408. --
+  def handle_info(
+        {:msg, %{status: status} = message},
+        %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
+      )
+      when batch_size > 1 and is_binary(status) and status != "" do
+    gen_state = maybe_handle_status(message, gen_state)
+    {:noreply, gen_state}
+  end
+
+  # -- Single-message mode: informational status. Drop + re-pull so the
+  # consumer doesn't stall. Matches the nats.go convention of never exposing
+  # status messages to the user's message handler. --
+  def handle_info(
+        {:msg, %{status: status} = message},
+        %__MODULE__{
+          connection_options: %ConnectionOptions{
+            stream_name: stream_name,
+            domain: domain
+          },
+          listening_topic: listening_topic,
+          consumer_name: consumer_name
+        } = gen_state
+      )
+      when is_binary(status) and status != "" do
+    gen_state = maybe_handle_status(message, gen_state)
+
+    next_message(
+      message.gnat,
+      stream_name,
+      consumer_name,
+      domain,
+      listening_topic
+    )
+
+    {:noreply, gen_state}
   end
 
   # -- Batch mode: data message — buffer until batch is full --

--- a/test/jetstream/api/kv/entry_test.exs
+++ b/test/jetstream/api/kv/entry_test.exs
@@ -1,0 +1,107 @@
+defmodule Gnat.Jetstream.API.KV.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Gnat.Jetstream.API.KV.Entry
+
+  @bucket "my_bucket"
+  @reply_to "$JS.ACK.KV_my_bucket.consumer.1.42.7.1750928948439739269.3"
+
+  describe "from_message/2" do
+    test "parses a put message with no headers" do
+      message = %{topic: "$KV.my_bucket.some.key", body: "hello", reply_to: @reply_to}
+
+      assert {:ok, entry} = Entry.from_message(message, @bucket)
+
+      assert %Entry{
+               bucket: "my_bucket",
+               key: "some.key",
+               value: "hello",
+               operation: :put,
+               revision: 42,
+               delta: 3
+             } = entry
+
+      assert %DateTime{} = entry.created
+    end
+
+    test "parses a put message when headers are present but not KV-operation" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "bar",
+        headers: [{"some-other", "value"}]
+      }
+
+      assert {:ok, %Entry{operation: :put, key: "foo", value: "bar"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "parses a DEL message as :delete" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"kv-operation", "DEL"}]
+      }
+
+      assert {:ok, %Entry{operation: :delete, key: "foo", value: ""}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "parses a PURGE message as :purge" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"kv-operation", "PURGE"}]
+      }
+
+      assert {:ok, %Entry{operation: :purge, key: "foo"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "treats a nats-marker-reason tombstone as :delete" do
+      message = %{
+        topic: "$KV.my_bucket.foo",
+        body: "",
+        headers: [{"nats-marker-reason", "MaxAge"}]
+      }
+
+      assert {:ok, %Entry{operation: :delete, key: "foo"}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "recovers keys that include dots" do
+      message = %{topic: "$KV.my_bucket.a.b.c", body: "v"}
+
+      assert {:ok, %Entry{key: "a.b.c"}} = Entry.from_message(message, @bucket)
+    end
+
+    test "leaves revision/created/delta nil when no reply_to is present" do
+      message = %{topic: "$KV.my_bucket.foo", body: "bar"}
+
+      assert {:ok, %Entry{revision: nil, created: nil, delta: nil}} =
+               Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore when the subject does not belong to the bucket" do
+      message = %{topic: "$KV.other_bucket.foo", body: "bar"}
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore for a 409 leadership-change status message" do
+      message = %{
+        topic: "_INBOX.foo",
+        body: "",
+        status: "409",
+        description: "Leadership Change"
+      }
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+
+    test "returns :ignore for a 100 idle heartbeat with no description" do
+      message = %{topic: "_INBOX.foo", body: "", status: "100"}
+
+      assert :ignore = Entry.from_message(message, @bucket)
+    end
+  end
+end

--- a/test/jetstream/api/kv/watcher_test.exs
+++ b/test/jetstream/api/kv/watcher_test.exs
@@ -1,0 +1,70 @@
+defmodule Gnat.Jetstream.API.KV.WatcherTest do
+  use Gnat.Jetstream.ConnCase, min_server_version: "2.6.2"
+
+  alias Gnat.Jetstream.API.KV
+
+  @moduletag with_gnat: :gnat
+
+  describe "status messages" do
+    setup do
+      bucket = "WATCHER_STATUS_TEST"
+      {:ok, _} = KV.create_bucket(:gnat, bucket)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        :ok = KV.delete_bucket(pid, bucket)
+        Gnat.stop(pid)
+      end)
+
+      test_pid = self()
+
+      {:ok, watcher} =
+        KV.watch(:gnat, bucket, fn action, key, value ->
+          send(test_pid, {action, key, value})
+        end)
+
+      on_exit(fn ->
+        if Process.alive?(watcher), do: KV.unwatch(watcher)
+      end)
+
+      %{watcher: watcher}
+    end
+
+    test "409 status messages are dropped", %{watcher: watcher} do
+      send(
+        watcher,
+        {:msg, %{status: "409", description: "Leadership Change", body: "", topic: "ignored"}}
+      )
+
+      refute_receive {:key_added, _, _}, 100
+      refute_receive {:key_deleted, _, _}, 100
+      assert Process.alive?(watcher)
+    end
+
+    test "100 idle heartbeat (no reply_to) is dropped", %{watcher: watcher} do
+      send(watcher, {:msg, %{status: "100", body: "", topic: "ignored"}})
+
+      refute_receive {:key_added, _, _}, 100
+      assert Process.alive?(watcher)
+    end
+
+    test "100 flow-control message is answered with an empty publish", %{watcher: watcher} do
+      reply_to = "_WATCHER_TEST.fc.#{System.unique_integer([:positive])}"
+      {:ok, _sub} = Gnat.sub(:gnat, self(), reply_to)
+
+      send(
+        watcher,
+        {:msg,
+         %{
+           status: "100",
+           description: "FlowControl Request",
+           body: "",
+           reply_to: reply_to,
+           topic: "ignored"
+         }}
+      )
+
+      assert_receive {:msg, %{topic: ^reply_to, body: ""}}, 500
+    end
+  end
+end

--- a/test/pull_consumer/status_messages_test.exs
+++ b/test/pull_consumer/status_messages_test.exs
@@ -1,0 +1,105 @@
+defmodule Gnat.Jetstream.PullConsumer.StatusMessagesTest do
+  use Gnat.Jetstream.ConnCase
+
+  alias Gnat.Jetstream.API.{Consumer, Stream}
+
+  defmodule ObservingConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+
+      {:ok, %{test_pid: test_pid},
+       Keyword.merge([connection_name: :gnat], opts)}
+    end
+
+    @impl true
+    def handle_message(message, state) do
+      send(state.test_pid, {:handle_message, message})
+      {:ack, state}
+    end
+
+    @impl true
+    def handle_status(message, state) do
+      send(state.test_pid, {:handle_status, message})
+      {:ok, state}
+    end
+  end
+
+  defmodule SilentConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts) do
+      Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+    end
+
+    @impl true
+    def init(opts) do
+      {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+
+      {:ok, test_pid, Keyword.merge([connection_name: :gnat], opts)}
+    end
+
+    @impl true
+    def handle_message(message, test_pid) do
+      send(test_pid, {:handle_message, message})
+      {:ack, test_pid}
+    end
+  end
+
+  describe "JetStream status messages" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream_name = "STATUS_TEST_STREAM"
+      consumer_name = "STATUS_TEST_CONSUMER"
+
+      stream = %Stream{name: stream_name, subjects: ["status.test"]}
+      {:ok, _} = Stream.create(:gnat, stream)
+
+      consumer = %Consumer{stream_name: stream_name, durable_name: consumer_name}
+      {:ok, _} = Consumer.create(:gnat, consumer)
+
+      on_exit(fn ->
+        {:ok, pid} = Gnat.start_link()
+        :ok = Stream.delete(pid, stream_name)
+        Gnat.stop(pid)
+      end)
+
+      %{stream_name: stream_name, consumer_name: consumer_name}
+    end
+
+    test "are not forwarded to handle_message when no handle_status is defined",
+         %{stream_name: stream_name, consumer_name: consumer_name} do
+      pid =
+        start_supervised!(
+          {SilentConsumer,
+           test_pid: self(), stream_name: stream_name, consumer_name: consumer_name}
+        )
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+      send(pid, {:msg, %{status: "100", body: "", gnat: :gnat}})
+
+      refute_receive {:handle_message, _}, 100
+    end
+
+    test "are forwarded to handle_status when the callback is defined",
+         %{stream_name: stream_name, consumer_name: consumer_name} do
+      pid =
+        start_supervised!(
+          {ObservingConsumer,
+           test_pid: self(), stream_name: stream_name, consumer_name: consumer_name}
+        )
+
+      send(pid, {:msg, %{status: "409", description: "Leadership Change", body: "", gnat: :gnat}})
+
+      assert_receive {:handle_status, %{status: "409", description: "Leadership Change"}}
+      refute_receive {:handle_message, _}, 100
+    end
+  end
+end


### PR DESCRIPTION
Introduces Gnat.Jetstream.API.KV.Entry.from_message/2 so PullConsumer-based KV cache implementations can share the same put/delete/purge parsing as KV.Watcher. Returns :ignore for non-KV messages. Watcher now uses it internally; its callback API is unchanged.

PullConsumer no longer forwards JetStream status messages (100, 404, 408, 409) to handle_message/2 since they are not ackable stream records. Single-message mode drops them and re-pulls. An optional handle_status/2 callback lets users observe them.