### PR TITLE
use server defaults and omit any non-user-specified options

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         pair:
           - otp: "25"
             elixir: "1.14"
-            nats: "2.10.0"
+            nats: "2.10.24"
 
           - otp: "26"
             elixir: "1.16"
@@ -29,25 +29,25 @@ jobs:
 
           - otp: "27"
             elixir: "1.17"
-            nats: "2.10.24"
+            nats: "2.11.17"
 
           - otp: "27"
             elixir: "1.18"
-            nats: "2.10.24"
-
-          - otp: "28"
-            elixir: "1.18"
-            nats: "2.11.11"
+            nats: "2.12.8"
 
           - otp: "28"
             elixir: "1.18"
             nats: "2.10.24"
 
-          # the main pair handles things like format checking and running dialyzer
-          - main: true
-            otp: "28"
+          - otp: "28"
+            elixir: "1.18"
+            nats: "2.11.17"
+            features: [message_ttl]
+
+          - otp: "28"
             elixir: "1.19"
-            nats: "2.10.24"
+            nats: "2.14.0"
+            features: [format, dialyzer, message_ttl]
 
     env:
       MIX_ENV: test
@@ -77,18 +77,18 @@ jobs:
         run: mix deps.get
 
       - name: Check for valid formatting
-        if: matrix.pair.main
+        if: contains(matrix.pair.features, 'format')
         run: mix format --check-formatted
 
       - name: Run unit tests
         run: mix test --color
 
-      - name: Run NATS 2.11 specific tests
-        if: ${{ matrix.pair.nats == '2.11.11' }}
+      - name: Run Message TTL Tests
+        if: contains(matrix.pair.features, 'message_ttl')
         run: mix test --only message_ttl
 
       - name: Cache Dialyzer PLTs
-        if: matrix.pair.main
+        if: contains(matrix.pair.features, 'dialyzer')
         uses: actions/cache@v4
         with:
           path: |
@@ -99,7 +99,7 @@ jobs:
             dialyzer-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-
 
       - name: Run Dialyzer
-        if: matrix.pair.main
+        if: contains(matrix.pair.features, 'dialyzer')
         env:
           MIX_ENV: dev
         run: |

--- a/bench/kv_consume.exs
+++ b/bench/kv_consume.exs
@@ -5,7 +5,9 @@
 #   1. Pager (batch 500, ack_policy: :all) — fetch a page, process, ack last, repeat
 #   2. Pull + ack_next pipeline (initial batch 500, ack_policy: :explicit) — prime the
 #      pipeline with a batch request, then ack_next each message to keep flow continuous
-#   3. PullConsumer with batch_size (ack_policy: :all) — the new batch mode using the
+#   3. KV.watch (PushConsumer) — uses the standard KV watcher which creates a push-based
+#      ephemeral consumer and delivers messages to a GenServer via handle_info
+#   4. PullConsumer with batch_size (ack_policy: :all) — the new batch mode using the
 #      actual PullConsumer behaviour, batches messages and acks only the last per batch
 #
 # Prerequisites:
@@ -177,7 +179,47 @@ defmodule KVConsumeBench do
   end
 
   # ---------------------------------------------------------------------------
-  # Strategy 3: PullConsumer with batch_size (ack_policy: :all, batch mode)
+  # Strategy 3: KV.watch (PushConsumer)
+  # ---------------------------------------------------------------------------
+  def watch_consume(conn, expected) do
+    tab = :ets.new(:watch_cache, [:set, :public])
+    notify = self()
+
+    counter = :counters.new(1, [:atomics])
+
+    {:ok, watcher} =
+      KV.watch(conn, @bucket, fn _action, key, value ->
+        :ets.insert(tab, {key, value})
+        :counters.add(counter, 1, 1)
+        count = :counters.get(counter, 1)
+
+        if count >= expected do
+          send(notify, {:watch_done, count})
+        end
+      end)
+
+    receive do
+      {:watch_done, _} -> :ok
+    after
+      60_000 ->
+        IO.puts("WARNING: KV.watch timeout")
+    end
+
+    count = :ets.info(tab, :size)
+    Process.unlink(watcher)
+
+    try do
+      KV.unwatch(watcher)
+    catch
+      :exit, _ -> :ok
+    end
+
+    :ets.delete(tab)
+    count
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strategy 4: PullConsumer with batch_size (ack_policy: :all, batch mode)
   #
   # Uses the actual PullConsumer behaviour with the new batch_size option.
   # This is the real-world usage pattern we want to validate.
@@ -248,10 +290,13 @@ IO.puts("  Pager:              #{count1} entries")
 count2 = KVConsumeBench.pull_ack_next_consume(conn, batch)
 IO.puts("  Pull+ack_next:      #{count2} entries")
 
-count3 = KVConsumeBench.batch_pull_consumer_consume(count, batch)
-IO.puts("  Batch PullConsumer: #{count3} entries")
+count3 = KVConsumeBench.watch_consume(conn, count)
+IO.puts("  KV.watch (push):    #{count3} entries")
 
-expected_counts = [count1, count2, count3]
+count4 = KVConsumeBench.batch_pull_consumer_consume(count, batch)
+IO.puts("  Batch PullConsumer: #{count4} entries")
+
+expected_counts = [count1, count2, count3, count4]
 
 if Enum.any?(expected_counts, &(&1 != count)) do
   IO.puts("\nERROR: expected #{count} entries from each approach")
@@ -270,6 +315,9 @@ Benchee.run(
     end,
     "pull+ack_next (initial batch #{batch})" => fn ->
       KVConsumeBench.pull_ack_next_consume(conn, batch)
+    end,
+    "kv_watch (push consumer)" => fn ->
+      KVConsumeBench.watch_consume(conn, count)
     end,
     "batch_pull_consumer (batch #{batch})" => fn ->
       KVConsumeBench.batch_pull_consumer_consume(count, batch)

--- a/lib/gnat/jetstream/api/kv/entry.ex
+++ b/lib/gnat/jetstream/api/kv/entry.ex
@@ -132,10 +132,10 @@ defmodule Gnat.Jetstream.API.KV.Entry do
 
   defp operation(_message), do: :put
 
-  defp apply_metadata(entry, message) do
+  defp apply_metadata(%__MODULE__{} = entry, message) do
     case Message.metadata(message) do
       {:ok, metadata} ->
-        %__MODULE__{
+        %{
           entry
           | revision: metadata.stream_seq,
             created: metadata.timestamp,

--- a/lib/gnat/jetstream/api/stream.ex
+++ b/lib/gnat/jetstream/api/stream.ex
@@ -6,8 +6,10 @@ defmodule Gnat.Jetstream.API.Stream do
 
   ## The Jetstream.API.Stream struct
 
-  The struct's mandatory fields are `:name` and `:subjects`. The rest will have the NATS
-  default values set.
+  The struct's mandatory fields are `:name` and `:subjects`. Any field left unset (`nil`)
+  is omitted from the request body, so the nats-server applies its own default. This keeps
+  the client compatible with both older servers that recognize legacy fields and newer
+  servers that have removed them.
 
   Stream struct fields explanation:
 
@@ -71,39 +73,54 @@ defmodule Gnat.Jetstream.API.Stream do
   import Gnat.Jetstream.API.Util
 
   @enforce_keys [:name, :subjects]
-  @derive {Jason.Encoder, except: [:domain]}
   defstruct [
+    :allow_direct,
+    :allow_msg_ttl,
+    :allow_rollup_hdrs,
+    :compression,
+    :deny_delete,
+    :deny_purge,
     :description,
-    :mirror,
-    :name,
+    :discard,
+    :discard_new_per_subject,
     :domain,
+    :duplicate_window,
+    :max_age,
+    :max_bytes,
+    :max_consumers,
+    :max_msg_size,
+    :max_msgs,
+    :max_msgs_per_subject,
+    :mirror,
+    :mirror_direct,
+    :name,
     :no_ack,
+    :num_replicas,
     :placement,
+    :retention,
+    :sealed,
     :sources,
+    :storage,
+    :subject_delete_marker_ttl,
     :subjects,
-    :template_owner,
-    allow_direct: false,
-    allow_msg_ttl: false,
-    allow_rollup_hdrs: false,
-    deny_delete: false,
-    deny_purge: false,
-    discard: :old,
-    duplicate_window: 120_000_000_000,
-    max_age: 0,
-    max_bytes: -1,
-    max_consumers: -1,
-    max_msg_size: -1,
-    max_msgs_per_subject: -1,
-    max_msgs: -1,
-    mirror_direct: false,
-    num_replicas: 1,
-    retention: :limits,
-    sealed: false,
-    storage: :file,
-    subject_delete_marker_ttl: 0,
-    discard_new_per_subject: false,
-    compression: "none"
+    :template_owner
   ]
+
+  defimpl Jason.Encoder do
+    # The Stream struct represents user intent: only fields the caller explicitly
+    # set (i.e. non-nil) get sent to the server. This keeps requests forward- and
+    # backward-compatible across nats-server versions that add or remove fields,
+    # since nats-server uses strict JSON parsing (DisallowUnknownFields) and will
+    # reject a request that contains fields it does not recognize. `:domain` is
+    # part of the API subject, not the request body.
+    def encode(stream, opts) do
+      stream
+      |> Map.from_struct()
+      |> Map.drop([:domain])
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
+      |> Jason.Encode.map(opts)
+    end
+  end
 
   @type nanoseconds :: non_neg_integer()
 
@@ -113,36 +130,36 @@ defmodule Gnat.Jetstream.API.Stream do
         }
 
   @type t :: %__MODULE__{
-          allow_direct: boolean(),
-          allow_msg_ttl: boolean(),
-          allow_rollup_hdrs: boolean(),
-          deny_delete: boolean(),
-          deny_purge: boolean(),
+          allow_direct: nil | boolean(),
+          allow_msg_ttl: nil | boolean(),
+          allow_rollup_hdrs: nil | boolean(),
+          compression: nil | binary(),
+          deny_delete: nil | boolean(),
+          deny_purge: nil | boolean(),
           description: nil | binary(),
-          discard: :old | :new,
+          discard: nil | :old | :new,
+          discard_new_per_subject: nil | boolean(),
           domain: nil | binary(),
           duplicate_window: nil | nanoseconds(),
-          max_age: nanoseconds(),
-          max_bytes: integer(),
-          max_consumers: integer(),
+          max_age: nil | nanoseconds(),
+          max_bytes: nil | integer(),
+          max_consumers: nil | integer(),
           max_msg_size: nil | integer(),
-          max_msgs: integer(),
-          max_msgs_per_subject: integer(),
+          max_msgs: nil | integer(),
+          max_msgs_per_subject: nil | integer(),
           mirror: nil | source(),
-          mirror_direct: boolean(),
+          mirror_direct: nil | boolean(),
           name: binary(),
           no_ack: nil | boolean(),
-          num_replicas: pos_integer(),
+          num_replicas: nil | pos_integer(),
           placement: nil | placement(),
-          retention: :limits | :workqueue | :interest,
-          sealed: boolean(),
+          retention: nil | :limits | :workqueue | :interest,
+          sealed: nil | boolean(),
           sources: nil | list(source()),
-          storage: :file | :memory,
+          storage: nil | :file | :memory,
+          subject_delete_marker_ttl: nil | nanoseconds(),
           subjects: nil | list(binary()),
-          subject_delete_marker_ttl: nanoseconds(),
-          template_owner: nil | binary(),
-          discard_new_per_subject: boolean(),
-          compression: binary()
+          template_owner: nil | binary()
         }
 
   @typedoc """
@@ -496,37 +513,52 @@ defmodule Gnat.Jetstream.API.Stream do
   defp to_stream(stream) do
     %__MODULE__{
       description: Map.get(stream, "description"),
-      discard: Map.fetch!(stream, "discard") |> to_sym(),
+      discard: stream |> Map.get("discard") |> to_discard(),
       duplicate_window: Map.get(stream, "duplicate_window"),
-      max_age: Map.fetch!(stream, "max_age"),
-      max_bytes: Map.fetch!(stream, "max_bytes"),
-      max_consumers: Map.fetch!(stream, "max_consumers"),
+      max_age: Map.get(stream, "max_age"),
+      max_bytes: Map.get(stream, "max_bytes"),
+      max_consumers: Map.get(stream, "max_consumers"),
       max_msg_size: Map.get(stream, "max_msg_size"),
-      max_msgs_per_subject: Map.get(stream, "max_msgs_per_subject", -1),
-      max_msgs: Map.fetch!(stream, "max_msgs"),
+      max_msgs_per_subject: Map.get(stream, "max_msgs_per_subject"),
+      max_msgs: Map.get(stream, "max_msgs"),
       mirror: Map.get(stream, "mirror"),
       name: Map.fetch!(stream, "name"),
       no_ack: Map.get(stream, "no_ack"),
-      num_replicas: Map.fetch!(stream, "num_replicas"),
+      num_replicas: Map.get(stream, "num_replicas"),
       placement: Map.get(stream, "placement"),
-      retention: Map.fetch!(stream, "retention") |> to_sym(),
+      retention: stream |> Map.get("retention") |> to_retention(),
       sources: Map.get(stream, "sources"),
-      storage: Map.fetch!(stream, "storage") |> to_sym(),
+      storage: stream |> Map.get("storage") |> to_storage(),
       subjects: Map.get(stream, "subjects"),
-      template_owner: Map.get(stream, "template_owner")
+      template_owner: Map.get(stream, "template_owner"),
+      allow_direct: Map.get(stream, "allow_direct"),
+      allow_msg_ttl: Map.get(stream, "allow_msg_ttl"),
+      allow_rollup_hdrs: Map.get(stream, "allow_rollup_hdrs"),
+      deny_delete: Map.get(stream, "deny_delete"),
+      deny_purge: Map.get(stream, "deny_purge"),
+      discard_new_per_subject: Map.get(stream, "discard_new_per_subject"),
+      mirror_direct: Map.get(stream, "mirror_direct"),
+      sealed: Map.get(stream, "sealed"),
+      subject_delete_marker_ttl: Map.get(stream, "subject_delete_marker_ttl"),
+      compression: Map.get(stream, "compression")
     }
-    # Check for fields added in NATS versions higher than 2.2.0
-    |> put_if_exist(:allow_direct, stream, "allow_direct")
-    |> put_if_exist(:allow_msg_ttl, stream, "allow_msg_ttl")
-    |> put_if_exist(:allow_rollup_hdrs, stream, "allow_rollup_hdrs")
-    |> put_if_exist(:deny_delete, stream, "deny_delete")
-    |> put_if_exist(:deny_purge, stream, "deny_purge")
-    |> put_if_exist(:discard_new_per_subject, stream, "discard_new_per_subject")
-    |> put_if_exist(:mirror_direct, stream, "mirror_direct")
-    |> put_if_exist(:sealed, stream, "sealed")
-    |> put_if_exist(:subject_delete_marker_ttl, stream, "subject_delete_marker_ttl")
-    |> put_if_exist(:compression, stream, "compression")
   end
+
+  # Explicit enum decoders. These also act as the only compile-time references
+  # to the known enum atoms; without them, `String.to_existing_atom/1` would
+  # fail at runtime since the struct no longer carries default atom values.
+  defp to_retention(nil), do: nil
+  defp to_retention("limits"), do: :limits
+  defp to_retention("workqueue"), do: :workqueue
+  defp to_retention("interest"), do: :interest
+
+  defp to_storage(nil), do: nil
+  defp to_storage("file"), do: :file
+  defp to_storage("memory"), do: :memory
+
+  defp to_discard(nil), do: nil
+  defp to_discard("old"), do: :old
+  defp to_discard("new"), do: :new
 
   defp to_info(%{"config" => config, "state" => state, "created" => created} = response) do
     with {:ok, created, _} <- DateTime.from_iso8601(created) do

--- a/test/jetstream/api/stream_encoder_test.exs
+++ b/test/jetstream/api/stream_encoder_test.exs
@@ -15,7 +15,7 @@ defmodule Gnat.Jetstream.API.StreamEncoderTest do
       stream = %Stream{name: "ORDERS", subjects: ["orders.*"]}
       keys = encoded_keys(stream)
 
-      assert keys == ["name", "subjects"]
+      assert Enum.sort(keys) == ["name", "subjects"]
     end
 
     test "does not send :template_owner unless the user set it (regression for #222)" do

--- a/test/jetstream/api/stream_encoder_test.exs
+++ b/test/jetstream/api/stream_encoder_test.exs
@@ -1,0 +1,116 @@
+defmodule Gnat.Jetstream.API.StreamEncoderTest do
+  # Pure unit tests for the Stream Jason.Encoder impl. These cover the
+  # serialization contract that issue #222 broke against nats-server 2.14:
+  # the server uses strict JSON parsing (DisallowUnknownFields), so the client
+  # must only send fields the user explicitly set.
+  use ExUnit.Case, async: true
+
+  alias Gnat.Jetstream.API.Stream
+
+  defp encoded_keys(stream), do: stream |> Jason.encode!() |> Jason.decode!() |> Map.keys()
+  defp decoded(stream), do: stream |> Jason.encode!() |> Jason.decode!()
+
+  describe "Jason.Encoder" do
+    test "omits nil-valued fields so unknown-field-strict servers accept the request" do
+      stream = %Stream{name: "ORDERS", subjects: ["orders.*"]}
+      keys = encoded_keys(stream)
+
+      assert keys == ["name", "subjects"]
+    end
+
+    test "does not send :template_owner unless the user set it (regression for #222)" do
+      stream = %Stream{name: "ORDERS", subjects: ["orders.*"]}
+      refute "template_owner" in encoded_keys(stream)
+    end
+
+    test "still sends :template_owner when the user explicitly set it" do
+      stream = %Stream{name: "ORDERS", subjects: ["orders.*"], template_owner: "tmpl-1"}
+      assert decoded(stream)["template_owner"] == "tmpl-1"
+    end
+
+    test "preserves boolean false (only nil is dropped)" do
+      stream = %Stream{name: "X", subjects: ["x"], deny_delete: false, allow_direct: false}
+      payload = decoded(stream)
+
+      assert payload["deny_delete"] == false
+      assert payload["allow_direct"] == false
+    end
+
+    test "preserves zero and -1 (only nil is dropped)" do
+      stream = %Stream{name: "X", subjects: ["x"], max_age: 0, max_bytes: -1}
+      payload = decoded(stream)
+
+      assert payload["max_age"] == 0
+      assert payload["max_bytes"] == -1
+    end
+
+    test "encodes atom enum values as strings the server understands" do
+      stream = %Stream{
+        name: "X",
+        subjects: ["x"],
+        retention: :workqueue,
+        storage: :memory,
+        discard: :new
+      }
+
+      payload = decoded(stream)
+
+      assert payload["retention"] == "workqueue"
+      assert payload["storage"] == "memory"
+      assert payload["discard"] == "new"
+    end
+
+    test "drops :domain (it's part of the API subject, not the request body)" do
+      stream = %Stream{name: "X", subjects: ["x"], domain: "leaf-1"}
+      refute "domain" in encoded_keys(stream)
+    end
+
+    test "passes nested maps (placement) through unchanged" do
+      placement = %{cluster: "us-east", tags: ["ssd", "fast"]}
+      stream = %Stream{name: "X", subjects: ["x"], placement: placement}
+
+      assert decoded(stream)["placement"] == %{
+               "cluster" => "us-east",
+               "tags" => ["ssd", "fast"]
+             }
+    end
+
+    test "round-trips a fully-populated stream without dropping fields" do
+      stream = %Stream{
+        name: "FULL",
+        subjects: ["full.*"],
+        description: "every field set",
+        retention: :limits,
+        storage: :file,
+        discard: :old,
+        max_age: 1_000,
+        max_bytes: 10_000,
+        max_consumers: 5,
+        max_msg_size: 1024,
+        max_msgs: 100,
+        max_msgs_per_subject: 10,
+        num_replicas: 3,
+        duplicate_window: 60_000_000_000,
+        no_ack: false,
+        sealed: false,
+        deny_delete: false,
+        deny_purge: false,
+        allow_direct: true,
+        allow_msg_ttl: true,
+        allow_rollup_hdrs: true,
+        mirror_direct: false,
+        discard_new_per_subject: false,
+        subject_delete_marker_ttl: 0,
+        compression: "s2",
+        template_owner: "tmpl"
+      }
+
+      payload = decoded(stream)
+
+      # name + subjects + 24 explicitly-set optional fields = 26
+      assert map_size(payload) == 26
+      assert payload["compression"] == "s2"
+      assert payload["template_owner"] == "tmpl"
+    end
+  end
+end

--- a/test/jetstream/api/stream_test.exs
+++ b/test/jetstream/api/stream_test.exs
@@ -10,7 +10,13 @@ defmodule Gnat.Jetstream.API.StreamTest do
 
     stream = %Stream{name: "LIST_TEST", subjects: ["STREAM_TEST"]}
     {:ok, response} = Stream.create(:gnat, stream)
-    assert response.config == stream
+    assert response.config.name == stream.name
+    assert response.config.subjects == stream.subjects
+    # server-applied defaults round-trip into the parsed config even though
+    # the client did not send them (see encoder: nil fields are omitted).
+    assert response.config.retention == :limits
+    assert response.config.storage == :file
+    assert response.config.discard == :old
 
     assert response.state == %{
              bytes: 0,
@@ -213,7 +219,8 @@ defmodule Gnat.Jetstream.API.StreamTest do
     assert {:ok, _response} = Stream.create(:gnat, stream)
 
     assert {:ok, response} = Stream.info(:gnat, "INFO_TEST")
-    assert response.config == stream
+    assert response.config.name == stream.name
+    assert response.config.subjects == stream.subjects
 
     assert response.state == %{
              bytes: 0,


### PR DESCRIPTION
Fixes #222 

This change removes all defaults from the client library and makes all fields in a stream `nilable`. The main idea here is that in order to be compatible with a wide range of server versions, we will have a single defined enum, but older servers may omit certain fields, so we allow those to be `nil` and we don't add any default values when a user is creating or updating a stream.