### PR TITLE
add heartbeat checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## 1.14
 
-* `PullConsumer` now requests an `idle_heartbeat` (default 15s) from the server
-  on every long-poll pull request and runs a local watchdog. If no traffic
-  (data, status, or `100` heartbeat) is observed within `2 * idle_heartbeat`,
-  the consumer assumes its pull request was lost (e.g. dropped during a
-  JetStream leadership change without killing the TCP connection) and forces
-  a reconnect. Configurable via the `:idle_heartbeat` and
-  `:heartbeat_check_interval` options.
+* `PullConsumer` now requests an `idle_heartbeat` (defaults to half of
+  `:request_expires`, i.e. 2.5s) from the server on every long-poll pull
+  request and runs a local watchdog. If no traffic (data, status, or `100`
+  heartbeat) is observed within `2 * idle_heartbeat`, the consumer assumes
+  its pull request was lost (e.g. dropped during a JetStream leadership
+  change without killing the TCP connection) and forces a reconnect.
+  Configurable via the `:idle_heartbeat` and `:heartbeat_check_interval`
+  options.
 * `PullConsumer` emits a new telemetry event
   `[:gnat, :jetstream, :pull_consumer, :heartbeat_expired]` when the watchdog
   fires. Measurements: `%{gap_ms, threshold_ms}`. Metadata:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 1.14
 
+* `PullConsumer` now requests an `idle_heartbeat` (default 15s) from the server
+  on every long-poll pull request and runs a local watchdog. If no traffic
+  (data, status, or `100` heartbeat) is observed within `2 * idle_heartbeat`,
+  the consumer assumes its pull request was lost (e.g. dropped during a
+  JetStream leadership change without killing the TCP connection) and forces
+  a reconnect. Configurable via the `:idle_heartbeat` and
+  `:heartbeat_check_interval` options.
+* `PullConsumer` emits a new telemetry event
+  `[:gnat, :jetstream, :pull_consumer, :heartbeat_expired]` when the watchdog
+  fires. Measurements: `%{gap_ms, threshold_ms}`. Metadata:
+  `%{module, stream_name, consumer_name, connection_name}`.
 * Add `PullConsumer.handle_connected/2` optional callback to get consumer info
 * Add `PullConsumer.handle_status/2` optional callback to observe status messages
 * Added support for `batch_size` option in PullConsumer options to pull messages

--- a/lib/gnat/jetstream/api/consumer.ex
+++ b/lib/gnat/jetstream/api/consumer.ex
@@ -357,6 +357,11 @@ defmodule Gnat.Jetstream.API.Consumer do
     the server. When set to true and no message is present to be consumed, a message with empty
     body and topic value set to `reply_to` is sent. Defaults to false.
 
+  * `idle_heartbeat` - Time in nanoseconds at which the server will emit a `100`-status
+    heartbeat message to `reply_to` while a long-poll pull request is outstanding but no
+    real messages are available. Useful for detecting dropped pull requests when the
+    underlying TCP connection has not died. Must be less than `expires`.
+
   ## Example
 
       iex> {:ok, _response} = Gnat.Jetstream.API.Stream.create(:gnat, %Gnat.Jetstream.API.Stream{name: "astream", subjects: ["subject"]})
@@ -397,6 +402,7 @@ defmodule Gnat.Jetstream.API.Consumer do
       |> put_option_if_not_nil.(:batch)
       |> put_option_if_not_nil.(:no_wait)
       |> put_option_if_not_nil.(:expires)
+      |> put_option_if_not_nil.(:idle_heartbeat)
       |> Jason.encode!()
 
     Gnat.pub(

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -71,8 +71,17 @@ defmodule Gnat.Jetstream.PullConsumer do
     that the server will clean it up. The `stream_name` field must also be set.
 
   You can also pass the optional ones:
-  * `:connection_retry_timeout` - a duration in milliseconds after which the PullConsumer which
-    failed to establish NATS connection retries, defaults to `1000`
+
+  > #### Time-unit gotcha {: .warning}
+  >
+  > Server-side JetStream options (`:request_expires`, `:idle_heartbeat`) take
+  > **nanoseconds** because that's what the JetStream wire protocol uses.
+  > Client-side options (`:connection_retry_timeout`, `:heartbeat_check_interval`)
+  > take **milliseconds**. The unit is called out per option below — double-check
+  > before tuning.
+
+  * `:connection_retry_timeout` - a duration in **milliseconds** after which the PullConsumer
+    which failed to establish NATS connection retries, defaults to `1000`
   * `:connection_retries` - a number of attempts the PullConsumer will make to establish the NATS
     connection. When this value is exceeded, the pull consumer stops with the `:timeout` reason,
     defaults to `10`
@@ -85,11 +94,10 @@ defmodule Gnat.Jetstream.PullConsumer do
     on large backlogs. In batch mode, `:nack` and `:term` returns from `c:handle_message/2`
     are treated as `:ack` since `ack_policy: :all` cannot selectively reject messages.
     Defaults to `1` (single-message mode).
-  * `:request_expires` - duration in nanoseconds a batch-mode pull request will linger on
-    the server while tailing (no backlog) before the server replies with a `408` terminator
-    and the consumer issues a fresh pull. Only used when `:batch_size` is greater than 1.
-    Defaults to `5_000_000_000` (5 seconds).
-  * `:idle_heartbeat` - duration in nanoseconds at which the server is asked to emit
+  * `:request_expires` - duration in **nanoseconds** that a long-poll pull request will linger on
+    the server before the server replies with a `408` terminator and the consumer issues a
+    fresh pull. Defaults to `5_000_000_000` (5 seconds).
+  * `:idle_heartbeat` - duration in **nanoseconds** at which the server is asked to emit
     `100`-status idle heartbeat messages while a long-poll pull request is outstanding
     but no real messages are available. The PullConsumer also runs a local watchdog: if
     no traffic at all (data, status, or heartbeat) is observed within `2 * idle_heartbeat`
@@ -98,7 +106,7 @@ defmodule Gnat.Jetstream.PullConsumer do
     Must be at most `:request_expires / 2` — the server rejects pull requests that
     violate this. Defaults to half of `:request_expires` (2.5 seconds with default
     settings, watchdog fires at 5s).
-  * `:heartbeat_check_interval` - cadence in milliseconds at which the local watchdog
+  * `:heartbeat_check_interval` - cadence in **milliseconds** at which the local watchdog
     checks for missed heartbeats. Independent of (and finer-grained than) the
     missed-heartbeat threshold itself. Defaults to `1_000` (1 second).
 

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -95,10 +95,12 @@ defmodule Gnat.Jetstream.PullConsumer do
     no traffic at all (data, status, or heartbeat) is observed within `2 * idle_heartbeat`
     the consumer assumes the pull request was lost (e.g. dropped during a JetStream
     leadership change without killing the TCP connection) and forces a reconnect.
-    Defaults to `15_000_000_000` (15 seconds, watchdog fires at 30s).
+    Must be at most `:request_expires / 2` — the server rejects pull requests that
+    violate this. Defaults to half of `:request_expires` (2.5 seconds with default
+    settings, watchdog fires at 5s).
   * `:heartbeat_check_interval` - cadence in milliseconds at which the local watchdog
     checks for missed heartbeats. Independent of (and finer-grained than) the
-    missed-heartbeat threshold itself. Defaults to `5_000` (5 seconds).
+    missed-heartbeat threshold itself. Defaults to `1_000` (1 second).
 
   ## Telemetry
 

--- a/lib/gnat/jetstream/pull_consumer.ex
+++ b/lib/gnat/jetstream/pull_consumer.ex
@@ -89,6 +89,26 @@ defmodule Gnat.Jetstream.PullConsumer do
     the server while tailing (no backlog) before the server replies with a `408` terminator
     and the consumer issues a fresh pull. Only used when `:batch_size` is greater than 1.
     Defaults to `5_000_000_000` (5 seconds).
+  * `:idle_heartbeat` - duration in nanoseconds at which the server is asked to emit
+    `100`-status idle heartbeat messages while a long-poll pull request is outstanding
+    but no real messages are available. The PullConsumer also runs a local watchdog: if
+    no traffic at all (data, status, or heartbeat) is observed within `2 * idle_heartbeat`
+    the consumer assumes the pull request was lost (e.g. dropped during a JetStream
+    leadership change without killing the TCP connection) and forces a reconnect.
+    Defaults to `15_000_000_000` (15 seconds, watchdog fires at 30s).
+  * `:heartbeat_check_interval` - cadence in milliseconds at which the local watchdog
+    checks for missed heartbeats. Independent of (and finer-grained than) the
+    missed-heartbeat threshold itself. Defaults to `5_000` (5 seconds).
+
+  ## Telemetry
+
+  The PullConsumer emits the following telemetry events:
+
+  * `[:gnat, :jetstream, :pull_consumer, :heartbeat_expired]` — emitted when the local
+    heartbeat watchdog observes that no inbound message has arrived within
+    `2 * idle_heartbeat` and the consumer is about to force a reconnect. Measurements:
+    `%{gap_ms, threshold_ms}`. Metadata: `%{module, stream_name, consumer_name,
+    connection_name}`.
 
   ## Dynamic Connection Options
 
@@ -366,6 +386,8 @@ defmodule Gnat.Jetstream.PullConsumer do
           | {:domain, String.t()}
           | {:batch_size, pos_integer()}
           | {:request_expires, non_neg_integer()}
+          | {:idle_heartbeat, non_neg_integer()}
+          | {:heartbeat_check_interval, non_neg_integer()}
 
   @typedoc """
   Connection options used to connect the consumer to NATS server.

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -14,6 +14,13 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
 
   # 5 Seconds in nanoseconds
   @default_request_expires 5_000_000_000
+  # 15 Seconds in nanoseconds — idle heartbeat sent by the server while a
+  # pull request is outstanding but no messages are available.
+  @default_idle_heartbeat 15_000_000_000
+  # How often the local watchdog checks whether we've heard anything from
+  # the server recently. Independent of (and finer-grained than) the
+  # missed-heartbeat threshold itself.
+  @default_heartbeat_check_interval 5_000
 
   defstruct @enforce_keys ++
               [
@@ -21,7 +28,9 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
                 :consumer_name,
                 :consumer,
                 batch_size: 1,
-                request_expires: @default_request_expires
+                request_expires: @default_request_expires,
+                idle_heartbeat: @default_idle_heartbeat,
+                heartbeat_check_interval: @default_heartbeat_check_interval
               ]
 
   def validate!(connection_options) do
@@ -36,7 +45,9 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
         inbox_prefix: nil,
         domain: nil,
         batch_size: 1,
-        request_expires: @default_request_expires
+        request_expires: @default_request_expires,
+        idle_heartbeat: @default_idle_heartbeat,
+        heartbeat_check_interval: @default_heartbeat_check_interval
       ])
 
     stream_name = validated_opts[:stream_name]

--- a/lib/gnat/jetstream/pull_consumer/connection_options.ex
+++ b/lib/gnat/jetstream/pull_consumer/connection_options.ex
@@ -14,22 +14,19 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
 
   # 5 Seconds in nanoseconds
   @default_request_expires 5_000_000_000
-  # 15 Seconds in nanoseconds — idle heartbeat sent by the server while a
-  # pull request is outstanding but no messages are available.
-  @default_idle_heartbeat 15_000_000_000
   # How often the local watchdog checks whether we've heard anything from
   # the server recently. Independent of (and finer-grained than) the
   # missed-heartbeat threshold itself.
-  @default_heartbeat_check_interval 5_000
+  @default_heartbeat_check_interval 1_000
 
   defstruct @enforce_keys ++
               [
                 :stream_name,
                 :consumer_name,
                 :consumer,
+                :idle_heartbeat,
                 batch_size: 1,
                 request_expires: @default_request_expires,
-                idle_heartbeat: @default_idle_heartbeat,
                 heartbeat_check_interval: @default_heartbeat_check_interval
               ]
 
@@ -40,21 +37,34 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectionOptions do
         :stream_name,
         :consumer_name,
         :consumer,
+        :idle_heartbeat,
         connection_retry_timeout: @default_retry_timeout,
         connection_retries: @default_retries,
         inbox_prefix: nil,
         domain: nil,
         batch_size: 1,
         request_expires: @default_request_expires,
-        idle_heartbeat: @default_idle_heartbeat,
         heartbeat_check_interval: @default_heartbeat_check_interval
       ])
 
     stream_name = validated_opts[:stream_name]
     consumer_name = validated_opts[:consumer_name]
     consumer = validated_opts[:consumer]
+    request_expires = validated_opts[:request_expires]
+    # idle_heartbeat defaults to half of request_expires so the value always
+    # respects the server's idle_heartbeat <= expires/2 constraint, no matter
+    # what request_expires the user picks.
+    idle_heartbeat = validated_opts[:idle_heartbeat] || div(request_expires, 2)
+
+    validated_opts = Keyword.put(validated_opts, :idle_heartbeat, idle_heartbeat)
 
     cond do
+      idle_heartbeat * 2 > request_expires ->
+        raise ArgumentError,
+              ":idle_heartbeat (#{idle_heartbeat}ns) must be at most half of " <>
+                ":request_expires (#{request_expires}ns) — the server rejects " <>
+                "pull requests where idle_heartbeat > expires/2"
+
       consumer && (stream_name || consumer_name) ->
         raise ArgumentError,
               "cannot specify :consumer with :stream_name or :consumer_name - use consumer struct's stream_name instead"

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -16,6 +16,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     :subscription_id,
     :connection_monitor_ref,
     :consumer_name,
+    :last_response_at,
     current_retry: 0,
     buffer: []
   ]
@@ -36,6 +37,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
           module: module,
           consumer_name: connection_options.consumer_name
         }
+
+        schedule_heartbeat_check(gen_state)
 
         {:connect, :init, gen_state}
 
@@ -91,16 +94,9 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
              consumer_name: final_consumer_name,
              state: state
          },
-         :ok <-
-           initial_fetch(
-             gen_state,
-             conn,
-             stream_name,
-             final_consumer_name,
-             domain,
-             listening_topic
-           ),
-         gen_state = %{gen_state | current_retry: 0} do
+         :ok <- initial_fetch(gen_state, conn),
+         gen_state = %{gen_state | current_retry: 0},
+         gen_state = touch_response(gen_state) do
       {:ok, gen_state}
     else
       {:error, reason} ->
@@ -267,6 +263,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
       )
       when batch_size > 1 do
+    gen_state = touch_response(gen_state)
     gen_state = maybe_handle_status(message, gen_state)
     {:noreply, gen_state}
   end
@@ -283,6 +280,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         } = gen_state
       )
       when batch_size > 1 and is_binary(status) and status != "" do
+    gen_state = touch_response(gen_state)
     gen_state = maybe_handle_status(message, gen_state)
 
     case buffer do
@@ -304,25 +302,13 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
   # status messages to the user's message handler. --
   def handle_info(
         {:msg, %{status: status} = message},
-        %__MODULE__{
-          connection_options: %ConnectionOptions{
-            stream_name: stream_name,
-            domain: domain
-          },
-          listening_topic: listening_topic,
-          consumer_name: consumer_name
-        } = gen_state
+        %__MODULE__{} = gen_state
       )
       when is_binary(status) and status != "" do
+    gen_state = touch_response(gen_state)
     gen_state = maybe_handle_status(message, gen_state)
 
-    next_message(
-      message.gnat,
-      stream_name,
-      consumer_name,
-      domain,
-      listening_topic
-    )
+    next_message(message.gnat, gen_state)
 
     {:noreply, gen_state}
   end
@@ -336,6 +322,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         } = gen_state
       )
       when batch_size > 1 do
+    gen_state = touch_response(gen_state)
     buffer = [message | buffer]
     gen_state = %{gen_state | buffer: buffer}
 
@@ -354,8 +341,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         %__MODULE__{
           connection_options: %ConnectionOptions{
             stream_name: stream_name,
-            connection_name: connection_name,
-            domain: domain
+            connection_name: connection_name
           },
           listening_topic: listening_topic,
           subscription_id: subscription_id,
@@ -364,6 +350,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
           consumer_name: consumer_name
         } = gen_state
       ) do
+    gen_state = touch_response(gen_state)
+
     Logger.debug(
       """
       #{__MODULE__} for #{stream_name}.#{consumer_name} received a message: \
@@ -384,41 +372,18 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
 
       {:nack, state} ->
         Gnat.Jetstream.nack(message)
-
-        next_message(
-          message.gnat,
-          stream_name,
-          consumer_name,
-          domain,
-          listening_topic
-        )
-
+        next_message(message.gnat, gen_state)
         gen_state = %{gen_state | state: state}
         {:noreply, gen_state}
 
       {:term, state} ->
         Gnat.Jetstream.ack_term(message)
-
-        next_message(
-          message.gnat,
-          stream_name,
-          consumer_name,
-          domain,
-          listening_topic
-        )
-
+        next_message(message.gnat, gen_state)
         gen_state = %{gen_state | state: state}
         {:noreply, gen_state}
 
       {:noreply, state} ->
-        next_message(
-          message.gnat,
-          stream_name,
-          consumer_name,
-          domain,
-          listening_topic
-        )
-
+        next_message(message.gnat, gen_state)
         gen_state = %{gen_state | state: state}
         {:noreply, gen_state}
     end
@@ -450,17 +415,63 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
       connection_name: connection_name
     )
 
-    # Clear consumer name on reconnect so it gets recreated (for ephemeral and auto-cleanup consumers)
-    # Clear buffer to avoid processing stale messages from the dead connection
-    gen_state = %{
-      gen_state
-      | consumer_name: nil,
-        subscription_id: nil,
-        connection_monitor_ref: nil,
-        buffer: []
-    }
+    {:connect, :reconnect, reset_to_disconnected(gen_state)}
+  end
 
-    {:connect, :reconnect, gen_state}
+  # -- Heartbeat watchdog: periodic check for "have we heard anything from
+  # the server recently?". Runs on a fixed cadence regardless of connection
+  # state. While disconnected (last_response_at == nil) it does nothing
+  # except reschedule itself. While connected, if the gap since the last
+  # inbound message exceeds `2 * idle_heartbeat`, we treat the pull as
+  # stuck and force a reconnect — this catches dropped pull requests where
+  # the TCP connection is otherwise healthy and no 408/409 is forthcoming. --
+  def handle_info(:heartbeat_check, %__MODULE__{} = gen_state) do
+    schedule_heartbeat_check(gen_state)
+
+    case heartbeat_status(gen_state) do
+      :ok ->
+        {:noreply, gen_state}
+
+      {:expired, gap_ms, threshold_ms} ->
+        %__MODULE__{
+          connection_options: %ConnectionOptions{
+            connection_name: connection_name,
+            stream_name: stream_name
+          },
+          listening_topic: listening_topic,
+          subscription_id: subscription_id,
+          module: module,
+          consumer_name: consumer_name
+        } = gen_state
+
+        Logger.warning(
+          """
+          #{__MODULE__} for #{stream_name}.#{consumer_name} has not received \
+          any traffic from the server in #{gap_ms}ms (threshold #{threshold_ms}ms). \
+          Forcing reconnect.
+          """,
+          module: module,
+          listening_topic: listening_topic,
+          subscription_id: subscription_id,
+          connection_name: connection_name
+        )
+
+        :telemetry.execute(
+          [:gnat, :jetstream, :pull_consumer, :heartbeat_expired],
+          %{gap_ms: gap_ms, threshold_ms: threshold_ms},
+          %{
+            module: module,
+            stream_name: stream_name,
+            consumer_name: consumer_name,
+            connection_name: connection_name
+          }
+        )
+
+        # Tear down the old subscription and monitor before reconnecting so
+        # we don't get a stale {:DOWN, ...} or stray inbox messages from
+        # the connection we're abandoning.
+        {:connect, :heartbeat_expired, reset_to_disconnected(gen_state)}
+    end
   end
 
   def handle_info(
@@ -514,7 +525,16 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     {:disconnect, {:close, from}, gen_state}
   end
 
-  defp next_message(conn, stream_name, consumer_name, domain, listening_topic) do
+  defp next_message(conn, gen_state) do
+    %{
+      connection_options: %ConnectionOptions{
+        stream_name: stream_name,
+        domain: domain
+      },
+      consumer_name: consumer_name,
+      listening_topic: listening_topic
+    } = gen_state
+
     Gnat.Jetstream.API.Consumer.request_next_message(
       conn,
       stream_name,
@@ -524,11 +544,11 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     )
   end
 
-  defp initial_fetch(gen_state, conn, stream_name, consumer_name, domain, listening_topic) do
+  defp initial_fetch(gen_state, conn) do
     if gen_state.connection_options.batch_size > 1 do
       request_batch(conn, gen_state, :catching_up)
     else
-      next_message(conn, stream_name, consumer_name, domain, listening_topic)
+      next_message(conn, gen_state)
     end
   end
 
@@ -538,7 +558,8 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
         stream_name: stream_name,
         batch_size: batch_size,
         domain: domain,
-        request_expires: expires
+        request_expires: expires,
+        idle_heartbeat: idle_heartbeat
       },
       consumer_name: consumer_name,
       listening_topic: listening_topic
@@ -546,8 +567,13 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
 
     opts =
       case mode do
-        :catching_up -> [batch: batch_size, no_wait: true]
-        :tailing -> [batch: batch_size, expires: expires]
+        :catching_up ->
+          # no_wait short-polls — server replies immediately with 404 if
+          # the stream is empty, so heartbeats are unnecessary.
+          [batch: batch_size, no_wait: true]
+
+        :tailing ->
+          [batch: batch_size, expires: expires, idle_heartbeat: idle_heartbeat]
       end
 
     Gnat.Jetstream.API.Consumer.request_next_message(
@@ -558,6 +584,67 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
       domain,
       opts
     )
+  end
+
+  # ---- Heartbeat watchdog helpers ----
+
+  defp touch_response(%__MODULE__{} = gen_state) do
+    %{gen_state | last_response_at: System.monotonic_time(:millisecond)}
+  end
+
+  defp schedule_heartbeat_check(%__MODULE__{
+         connection_options: %ConnectionOptions{heartbeat_check_interval: interval}
+       }) do
+    Process.send_after(self(), :heartbeat_check, interval)
+    :ok
+  end
+
+  defp heartbeat_status(%__MODULE__{last_response_at: nil}), do: :ok
+
+  defp heartbeat_status(%__MODULE__{
+         last_response_at: last,
+         connection_options: %ConnectionOptions{idle_heartbeat: idle_heartbeat_ns}
+       }) do
+    threshold_ms = div(idle_heartbeat_ns, 1_000_000) * 2
+    gap_ms = System.monotonic_time(:millisecond) - last
+
+    if gap_ms > threshold_ms do
+      {:expired, gap_ms, threshold_ms}
+    else
+      :ok
+    end
+  end
+
+  # Tear down everything tied to the current Gnat connection and reset the
+  # corresponding fields in gen_state. Side effects and state mutation live
+  # together so callers don't have to remember to do both.
+  #
+  # Safe to call from any path:
+  #   * Heartbeat-expired reconnect: connection still alive, demonitor +
+  #     unsub do real work.
+  #   * :DOWN handler: monitor already fired (demonitor is a no-op) and the
+  #     Gnat pid is gone (connection_pid returns :not_found, unsub skipped).
+  defp reset_to_disconnected(%__MODULE__{} = gen_state) do
+    if gen_state.connection_monitor_ref do
+      Process.demonitor(gen_state.connection_monitor_ref, [:flush])
+    end
+
+    if gen_state.subscription_id do
+      with {:ok, conn} <- connection_pid(gen_state.connection_options.connection_name) do
+        # Best-effort: if the connection is already gone, there is nothing
+        # to unsubscribe from. We don't surface the error.
+        _ = Gnat.unsub(conn, gen_state.subscription_id)
+      end
+    end
+
+    %{
+      gen_state
+      | consumer_name: nil,
+        subscription_id: nil,
+        connection_monitor_ref: nil,
+        buffer: [],
+        last_response_at: nil
+    }
   end
 
   defp process_and_ack_batch(%{buffer: buffer, module: module, state: state} = gen_state) do

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -14,6 +14,7 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     :listening_topic,
     :module,
     :subscription_id,
+    :connection_pid,
     :connection_monitor_ref,
     :consumer_name,
     :last_response_at,
@@ -73,6 +74,15 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
       connection_name: connection_name
     )
 
+    # Mint a fresh inbox on every (re)connect. Reusing the same topic across
+    # reconnects lets messages from an abandoned pull on the previous
+    # connection leak into the new subscription's mailbox; rotating it
+    # makes those messages addressed to a topic we no longer subscribe to,
+    # and the per-message topic guard in handle_info/2 will drop any that
+    # do still arrive (e.g. delivered locally before unsub propagated).
+    listening_topic =
+      Util.reply_inbox(gen_state.connection_options.inbox_prefix)
+
     with {:ok, conn} <- connection_pid(connection_name),
          monitor_ref = Process.monitor(conn),
          {:ok, consumer_info} <-
@@ -90,8 +100,10 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
          gen_state = %{
            gen_state
            | subscription_id: sid,
+             connection_pid: conn,
              connection_monitor_ref: monitor_ref,
              consumer_name: final_consumer_name,
+             listening_topic: listening_topic,
              state: state
          },
          :ok <- initial_fetch(gen_state, conn),
@@ -256,13 +268,43 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     end
   end
 
-  # -- Batch mode: 100 is an idle heartbeat — the pull is still alive, do
-  # nothing but invoke the user callback. --
+  # -- Drop messages from a stale Gnat subscription. After a reconnect we
+  # mint a fresh inbox + subscription id (sid), but messages already in
+  # flight to the prior subscription can still arrive locally. Acking,
+  # processing, or re-pulling on those would corrupt the new subscription's
+  # state, so we log and drop.
+  #
+  # Gnat's :msg struct doesn't carry the inbox we subscribed on — only the
+  # original publish topic, the connection pid, and an integer sid. So we
+  # identify the current subscription by the (gnat_pid, sid) pair. This
+  # tuple is unique even across Gnat process restarts: a new Gnat process
+  # has a different pid, so its first sid=1 won't collide with the old
+  # process's sid=1. --
   def handle_info(
-        {:msg, %{status: "100"} = message},
-        %__MODULE__{connection_options: %ConnectionOptions{batch_size: batch_size}} = gen_state
+        {:msg, %{gnat: msg_gnat, sid: msg_sid} = message},
+        %__MODULE__{connection_pid: conn, subscription_id: sid} = gen_state
       )
-      when batch_size > 1 do
+      when is_integer(sid) and (msg_gnat != conn or msg_sid != sid) do
+    Logger.warning(
+      "#{__MODULE__} dropping message from stale subscription " <>
+        "(msg=#{inspect(msg_gnat)}/#{inspect(msg_sid)}, " <>
+        "current=#{inspect(conn)}/#{inspect(sid)}, " <>
+        "topic=#{inspect(Map.get(message, :topic))}, " <>
+        "status=#{inspect(Map.get(message, :status))})",
+      module: gen_state.module,
+      listening_topic: gen_state.listening_topic,
+      connection_name: gen_state.connection_options.connection_name
+    )
+
+    {:noreply, gen_state}
+  end
+
+  # -- 100 is an idle heartbeat — the pull is still alive, do nothing but
+  # feed the watchdog and invoke the user callback. Applies to both
+  # single-message and batch modes; do NOT re-pull (issuing a fresh pull on
+  # every heartbeat causes the server-side pull queue to grow without
+  # bound). --
+  def handle_info({:msg, %{status: "100"} = message}, %__MODULE__{} = gen_state) do
     gen_state = touch_response(gen_state)
     gen_state = maybe_handle_status(message, gen_state)
     {:noreply, gen_state}
@@ -529,18 +571,25 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
     %{
       connection_options: %ConnectionOptions{
         stream_name: stream_name,
-        domain: domain
+        domain: domain,
+        request_expires: expires,
+        idle_heartbeat: idle_heartbeat
       },
       consumer_name: consumer_name,
       listening_topic: listening_topic
     } = gen_state
 
+    # Single-message-mode pulls long-poll the same way batch mode does in
+    # :tailing — expires bounds the wait, idle_heartbeat keeps the watchdog
+    # fed during quiet periods.
     Gnat.Jetstream.API.Consumer.request_next_message(
       conn,
       stream_name,
       consumer_name,
       listening_topic,
-      domain
+      domain,
+      expires: expires,
+      idle_heartbeat: idle_heartbeat
     )
   end
 
@@ -641,7 +690,9 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
       gen_state
       | consumer_name: nil,
         subscription_id: nil,
+        connection_pid: nil,
         connection_monitor_ref: nil,
+        listening_topic: nil,
         buffer: [],
         last_response_at: nil
     }

--- a/lib/gnat/jetstream/pull_consumer/server.ex
+++ b/lib/gnat/jetstream/pull_consumer/server.ex
@@ -674,15 +674,56 @@ defmodule Gnat.Jetstream.PullConsumer.Server do
   #   * :DOWN handler: monitor already fired (demonitor is a no-op) and the
   #     Gnat pid is gone (connection_pid returns :not_found, unsub skipped).
   defp reset_to_disconnected(%__MODULE__{} = gen_state) do
+    # Always flush any buffered messages through the user's handler
+    # before tearing down. The handler invocation is pure consumer-side
+    # work and is always safe; the ack is best-effort against the
+    # original Gnat pid. If the ack fails, the server will redeliver
+    # after ack_wait and at-least-once is preserved.
+    #
+    # Why we MUST do this for batch mode: under ack_policy: :all,
+    # acking message N moves the consumer's ack_floor to N, covering
+    # everything ≤ N. If we silently drop a partial batch [101..115]
+    # and a later batch's ack on seq 125 arrives, the server treats
+    # 101..115 as acked and never redelivers them — a true loss.
+    gen_state =
+      if gen_state.buffer == [] do
+        gen_state
+      else
+        Logger.info(
+          "[#{__MODULE__}] flushing #{length(gen_state.buffer)} buffered messages " <>
+            "before reconnect for #{gen_state.connection_options.stream_name}.#{gen_state.consumer_name}"
+        )
+
+        try do
+          process_and_ack_batch(gen_state)
+        catch
+          :exit, reason ->
+            # Ack publish failed (Gnat pid is dead, dying, or wedged).
+            # The user's handler already ran for these messages, and
+            # the server will redeliver after ack_wait — both halves
+            # of at-least-once are covered.
+            Logger.info(
+              "[#{__MODULE__}] ack of flushed batch failed (#{inspect(reason)}); " <>
+                "messages will be redelivered after ack_wait"
+            )
+
+            %{gen_state | buffer: []}
+        end
+      end
+
     if gen_state.connection_monitor_ref do
       Process.demonitor(gen_state.connection_monitor_ref, [:flush])
     end
 
-    if gen_state.subscription_id do
-      with {:ok, conn} <- connection_pid(gen_state.connection_options.connection_name) do
-        # Best-effort: if the connection is already gone, there is nothing
-        # to unsubscribe from. We don't surface the error.
-        _ = Gnat.unsub(conn, gen_state.subscription_id)
+    if gen_state.subscription_id && is_pid(gen_state.connection_pid) do
+      # Best-effort unsub against the same Gnat that owns the sid (the
+      # pid we stored on the successful sub, not Process.whereis(name)
+      # which could resolve to a fresh-but-wedged Gnat after a restart).
+      # try/catch covers a dead pid or a slow GenServer.call.
+      try do
+        _ = Gnat.unsub(gen_state.connection_pid, gen_state.subscription_id)
+      catch
+        :exit, _ -> :ok
       end
     end
 

--- a/test/pull_consumer/connectivity_test.exs
+++ b/test/pull_consumer/connectivity_test.exs
@@ -159,7 +159,8 @@ defmodule Gnat.Jetstream.PullConsumer.ConnectivityTest do
 
       :ok = Gnat.pub(:gnat, "ackable", "hello")
 
-      expected_body = %{batch: 1} |> Jason.encode!()
+      expected_body =
+        %{batch: 1, idle_heartbeat: 2_500_000_000, expires: 5_000_000_000} |> Jason.encode!()
 
       assert_receive {:msg, %{body: ^expected_body, reply_to: "CUSTOM_PREFIX." <> _}}
     end

--- a/test/pull_consumer/heartbeat_test.exs
+++ b/test/pull_consumer/heartbeat_test.exs
@@ -1,0 +1,139 @@
+defmodule Gnat.Jetstream.PullConsumer.HeartbeatTest do
+  use Gnat.Jetstream.ConnCase
+
+  alias Gnat.Jetstream.API.{Consumer, Stream}
+  alias Gnat.Jetstream.PullConsumer.ConnectionOptions
+
+  defmodule IdleConsumer do
+    use Gnat.Jetstream.PullConsumer
+
+    def start_link(opts), do: Gnat.Jetstream.PullConsumer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts), do: {:ok, nil, Keyword.merge([connection_name: :gnat], opts)}
+
+    @impl true
+    def handle_message(_msg, state), do: {:ack, state}
+  end
+
+  describe "ConnectionOptions.validate!/1 — heartbeat options" do
+    test "defaults idle_heartbeat to half of request_expires" do
+      opts =
+        ConnectionOptions.validate!(
+          connection_name: :gnat,
+          stream_name: "S",
+          consumer_name: "C"
+        )
+
+      assert opts.idle_heartbeat == div(opts.request_expires, 2)
+    end
+
+    test "explicit idle_heartbeat is preserved" do
+      opts =
+        ConnectionOptions.validate!(
+          connection_name: :gnat,
+          stream_name: "S",
+          consumer_name: "C",
+          request_expires: 4_000_000_000,
+          idle_heartbeat: 1_000_000_000
+        )
+
+      assert opts.idle_heartbeat == 1_000_000_000
+    end
+
+    test "rejects idle_heartbeat > request_expires / 2" do
+      assert_raise ArgumentError, ~r/idle_heartbeat.*must be at most half of/, fn ->
+        ConnectionOptions.validate!(
+          connection_name: :gnat,
+          stream_name: "S",
+          consumer_name: "C",
+          request_expires: 1_000_000_000,
+          idle_heartbeat: 800_000_000
+        )
+      end
+    end
+
+    test "accepts idle_heartbeat exactly equal to request_expires / 2" do
+      opts =
+        ConnectionOptions.validate!(
+          connection_name: :gnat,
+          stream_name: "S",
+          consumer_name: "C",
+          request_expires: 2_000_000_000,
+          idle_heartbeat: 1_000_000_000
+        )
+
+      assert opts.idle_heartbeat == 1_000_000_000
+    end
+
+    test "defaults heartbeat_check_interval to 1 second" do
+      opts =
+        ConnectionOptions.validate!(
+          connection_name: :gnat,
+          stream_name: "S",
+          consumer_name: "C"
+        )
+
+      assert opts.heartbeat_check_interval == 1_000
+    end
+  end
+
+  describe "watchdog behavior — single-message mode (batch_size: 1)" do
+    @describetag with_gnat: :gnat
+
+    setup do
+      stream_name = "HB_TEST_STREAM"
+      consumer_name = "HB_TEST_CONSUMER"
+
+      stream = %Stream{name: stream_name, subjects: ["hb.test"]}
+      {:ok, _} = Stream.create(:gnat, stream)
+
+      consumer = %Consumer{stream_name: stream_name, durable_name: consumer_name}
+      {:ok, _} = Consumer.create(:gnat, consumer)
+
+      on_exit(fn ->
+        cleanup(stream_name)
+      end)
+
+      %{stream_name: stream_name, consumer_name: consumer_name}
+    end
+
+    @tag :integration
+    test "does not fire watchdog on idle stream", %{
+      stream_name: stream_name,
+      consumer_name: consumer_name
+    } do
+      test_pid = self()
+
+      :ok =
+        :telemetry.attach(
+          "hb-test-#{System.unique_integer()}",
+          [:gnat, :jetstream, :pull_consumer, :heartbeat_expired],
+          fn _e, m, meta, _ -> send(test_pid, {:watchdog, m, meta}) end,
+          nil
+        )
+
+      # Tight timings so we don't have to wait long, but still respect
+      # idle_heartbeat <= request_expires / 2.
+      start_supervised!(
+        {IdleConsumer,
+         stream_name: stream_name,
+         consumer_name: consumer_name,
+         request_expires: 1_000_000_000,
+         idle_heartbeat: 500_000_000,
+         heartbeat_check_interval: 200}
+      )
+
+      # Watchdog threshold is 2 * 500ms = 1000ms. If the bug were present,
+      # we'd see a fire within ~1.2s. Wait long enough for two threshold
+      # windows to confirm the watchdog stays quiet.
+      refute_receive {:watchdog, _, _}, 3_000
+    end
+  end
+
+  defp cleanup(stream_name) do
+    {:ok, pid} = Gnat.start_link()
+    _ = Stream.delete(pid, stream_name)
+    Gnat.stop(pid)
+  end
+end


### PR DESCRIPTION
including the use of idle_heartbeat for pull requests

This addresses #220 as well as various edge-cases that can happen such as a leadership change at a time when the route is unhealthy, or a `NXT` acknowledgement that doesn't make it back to the jetstream server for various reasons.

@autodidaddict @awoimbee would love any thoughts from you