### PR TITLE
Fix large payload parsing performance

### DIFF
--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -174,6 +174,8 @@ defmodule Gnat.Parsec do
   # Accumulate incoming TCP chunks into an iolist until enough bytes have arrived for the
   # full message body (plus the trailing \r\n). Returns {:accumulating, chunks, have} when
   # more data is still needed, or {:complete, binary} when ready to extract the body.
+  @spec accumulate_body(iolist(), non_neg_integer(), binary(), non_neg_integer()) ::
+          {:accumulating, iolist(), non_neg_integer()} | {:complete, binary()}
   defp accumulate_body(chunks, have, string, needed_length) do
     new_have = have + byte_size(string)
     new_chunks = [chunks, string]

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -99,7 +99,21 @@ defmodule Gnat.Parsec do
 
   def new, do: %__MODULE__{}
 
-  # Fast path: we already parsed the MSG header and are just waiting for the body bytes.
+  # Hot path: no partial header fragment, no pending body. This is the common case for
+  # small messages that arrive complete in a single TCP chunk.
+  def parse(%__MODULE__{partial: nil, pending: nil} = state, string) do
+    {partial, pending, commands} = parse_commands(string, [])
+    {%{state | partial: partial, pending: pending}, commands}
+  end
+
+  # Hot path variant: we have a partial header fragment from the previous chunk.
+  # Prepend it and re-parse. Only the header is small, so the binary concatenation is cheap.
+  def parse(%__MODULE__{partial: partial, pending: nil} = state, string) do
+    {new_partial, pending, commands} = parse_commands(partial <> string, [])
+    {%{state | partial: new_partial, pending: pending}, commands}
+  end
+
+  # Large-payload path: we already parsed the MSG header and are waiting for body bytes.
   # Accumulate incoming chunks into an iolist and only call iolist_to_binary once we have
   # enough bytes. This avoids the O(n²) cost of `partial <> string` that the original code
   # incurred — copying the entire accumulated buffer on every TCP chunk.
@@ -146,16 +160,6 @@ defmodule Gnat.Parsec do
     else
       {%{state | pending: {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}}, []}
     end
-  end
-
-  def parse(%__MODULE__{partial: nil, pending: nil} = state, string) do
-    {partial, pending, commands} = parse_commands(string, [])
-    {%{state | partial: partial, pending: pending}, commands}
-  end
-
-  def parse(%__MODULE__{partial: partial, pending: nil} = state, string) do
-    {new_partial, pending, commands} = parse_commands(partial <> string, [])
-    {%{state | partial: new_partial, pending: pending}, commands}
   end
 
   def parse_commands("", list), do: {nil, nil, Enum.reverse(list)}

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -121,18 +121,21 @@ defmodule Gnat.Parsec do
         %__MODULE__{pending: {:msg, subject, sid, reply_to, length, chunks, have}} = state,
         string
       ) do
-    new_have = have + byte_size(string)
-    new_chunks = [chunks, string]
+    case accumulate_body(chunks, have, string, length) do
+      {:accumulating, new_chunks, new_have} ->
+        {%{state | pending: {:msg, subject, sid, reply_to, length, new_chunks, new_have}}, []}
 
-    if new_have >= length + 2 do
-      binary = :erlang.iolist_to_binary(new_chunks)
-      <<body::binary-size(length), "\r\n", rest::binary>> = binary
-      {new_partial, new_pending, more} = parse_commands(rest, [])
+      {:complete, binary} ->
+        case binary do
+          <<body::binary-size(length), "\r\n", rest::binary>> ->
+            {new_partial, new_pending, more} = parse_commands(rest, [])
 
-      {%{state | partial: new_partial, pending: new_pending},
-       [{:msg, subject, sid, reply_to, body} | more]}
-    else
-      {%{state | pending: {:msg, subject, sid, reply_to, length, new_chunks, new_have}}, []}
+            {%{state | partial: new_partial, pending: new_pending},
+             [{:msg, subject, sid, reply_to, body} | more]}
+
+          _other ->
+            raise "malformed MSG termination: expected \\r\\n after #{length} byte body"
+        end
     end
   end
 
@@ -142,27 +145,43 @@ defmodule Gnat.Parsec do
         } = state,
         string
       ) do
+    case accumulate_body(chunks, have, string, total_length) do
+      {:accumulating, new_chunks, new_have} ->
+        {%{
+           state
+           | pending:
+               {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}
+         }, []}
+
+      {:complete, binary} ->
+        payload_length = total_length - header_length
+
+        case binary do
+          <<headers_bin::binary-size(header_length), payload::binary-size(payload_length), "\r\n",
+            rest::binary>> ->
+            {:ok, status, description, headers} = parse_headers(headers_bin)
+            {new_partial, new_pending, more} = parse_commands(rest, [])
+
+            {%{state | partial: new_partial, pending: new_pending},
+             [{:hmsg, subject, sid, reply_to, status, description, headers, payload} | more]}
+
+          _other ->
+            raise "malformed HMSG termination: expected \\r\\n after #{total_length} byte payload"
+        end
+    end
+  end
+
+  # Accumulate incoming TCP chunks into an iolist until enough bytes have arrived for the
+  # full message body (plus the trailing \r\n). Returns {:accumulating, chunks, have} when
+  # more data is still needed, or {:complete, binary} when ready to extract the body.
+  defp accumulate_body(chunks, have, string, needed_length) do
     new_have = have + byte_size(string)
     new_chunks = [chunks, string]
 
-    if new_have >= total_length + 2 do
-      payload_length = total_length - header_length
-      binary = :erlang.iolist_to_binary(new_chunks)
-
-      <<headers_bin::binary-size(header_length), payload::binary-size(payload_length), "\r\n",
-        rest::binary>> = binary
-
-      {:ok, status, description, headers} = parse_headers(headers_bin)
-      {new_partial, new_pending, more} = parse_commands(rest, [])
-
-      {%{state | partial: new_partial, pending: new_pending},
-       [{:hmsg, subject, sid, reply_to, status, description, headers, payload} | more]}
+    if new_have >= needed_length + 2 do
+      {:complete, :erlang.iolist_to_binary(new_chunks)}
     else
-      {%{
-         state
-         | pending:
-             {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}
-       }, []}
+      {:accumulating, new_chunks, new_have}
     end
   end
 

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -149,8 +149,8 @@ defmodule Gnat.Parsec do
       payload_length = total_length - header_length
       binary = :erlang.iolist_to_binary(new_chunks)
 
-      <<headers_bin::binary-size(header_length), payload::binary-size(payload_length),
-        "\r\n", rest::binary>> = binary
+      <<headers_bin::binary-size(header_length), payload::binary-size(payload_length), "\r\n",
+        rest::binary>> = binary
 
       {:ok, status, description, headers} = parse_headers(headers_bin)
       {new_partial, new_pending, more} = parse_commands(rest, [])
@@ -158,7 +158,11 @@ defmodule Gnat.Parsec do
       {%{state | partial: new_partial, pending: new_pending},
        [{:hmsg, subject, sid, reply_to, status, description, headers, payload} | more]}
     else
-      {%{state | pending: {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}}, []}
+      {%{
+         state
+         | pending:
+             {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}
+       }, []}
     end
   end
 

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -1,6 +1,6 @@
 defmodule Gnat.Parsec do
   @moduledoc false
-  defstruct partial: nil
+  defstruct partial: nil, pending: nil
 
   import NimbleParsec
 
@@ -99,26 +99,77 @@ defmodule Gnat.Parsec do
 
   def new, do: %__MODULE__{}
 
-  def parse(%__MODULE__{partial: nil} = state, string) do
-    {partial, commands} = parse_commands(string, [])
-    {%{state | partial: partial}, commands}
+  # Fast path: we already parsed the MSG header and are just waiting for the body bytes.
+  # Accumulate incoming chunks into an iolist and only call iolist_to_binary once we have
+  # enough bytes. This avoids the O(n²) cost of `partial <> string` that the original code
+  # incurred — copying the entire accumulated buffer on every TCP chunk.
+  def parse(
+        %__MODULE__{pending: {:msg, subject, sid, reply_to, length, chunks, have}} = state,
+        string
+      ) do
+    new_have = have + byte_size(string)
+    new_chunks = [chunks, string]
+
+    if new_have >= length + 2 do
+      binary = :erlang.iolist_to_binary(new_chunks)
+      <<body::binary-size(length), "\r\n", rest::binary>> = binary
+      {new_partial, new_pending, more} = parse_commands(rest, [])
+
+      {%{state | partial: new_partial, pending: new_pending},
+       [{:msg, subject, sid, reply_to, body} | more]}
+    else
+      {%{state | pending: {:msg, subject, sid, reply_to, length, new_chunks, new_have}}, []}
+    end
   end
 
-  def parse(%__MODULE__{partial: partial} = state, string) do
-    {partial, commands} = parse_commands(partial <> string, [])
-    {%{state | partial: partial}, commands}
+  def parse(
+        %__MODULE__{
+          pending: {:hmsg, subject, sid, reply_to, header_length, total_length, chunks, have}
+        } = state,
+        string
+      ) do
+    new_have = have + byte_size(string)
+    new_chunks = [chunks, string]
+
+    if new_have >= total_length + 2 do
+      payload_length = total_length - header_length
+      binary = :erlang.iolist_to_binary(new_chunks)
+
+      <<headers_bin::binary-size(header_length), payload::binary-size(payload_length),
+        "\r\n", rest::binary>> = binary
+
+      {:ok, status, description, headers} = parse_headers(headers_bin)
+      {new_partial, new_pending, more} = parse_commands(rest, [])
+
+      {%{state | partial: new_partial, pending: new_pending},
+       [{:hmsg, subject, sid, reply_to, status, description, headers, payload} | more]}
+    else
+      {%{state | pending: {:hmsg, subject, sid, reply_to, header_length, total_length, new_chunks, new_have}}, []}
+    end
   end
 
-  def parse_commands("", list), do: {nil, Enum.reverse(list)}
+  def parse(%__MODULE__{partial: nil, pending: nil} = state, string) do
+    {partial, pending, commands} = parse_commands(string, [])
+    {%{state | partial: partial, pending: pending}, commands}
+  end
+
+  def parse(%__MODULE__{partial: partial, pending: nil} = state, string) do
+    {new_partial, pending, commands} = parse_commands(partial <> string, [])
+    {%{state | partial: new_partial, pending: pending}, commands}
+  end
+
+  def parse_commands("", list), do: {nil, nil, Enum.reverse(list)}
 
   def parse_commands(str, list) do
     case parse_command(str) do
       {:ok, command, rest} -> parse_commands(rest, [command | list])
-      {:error, partial} -> {partial, Enum.reverse(list)}
+      {:pending, pending_info} -> {nil, pending_info, Enum.reverse(list)}
+      {:error, partial} -> {partial, nil, Enum.reverse(list)}
     end
   end
 
-  @spec parse_command(binary()) :: {:ok, tuple(), binary()} | {:error, binary()}
+  @spec parse_command(binary()) ::
+          {:ok, tuple(), binary()} | {:pending, tuple()} | {:error, binary()}
   def parse_command(string) do
     case command(string) do
       {:ok, [:msg, subject, sid, length], rest, _, _, _} ->
@@ -179,17 +230,20 @@ defmodule Gnat.Parsec do
     {:error, "Could not parse status line prefix"}
   end
 
-  def finish_msg(subject, sid, reply_to, length, rest, string) do
+  def finish_msg(subject, sid, reply_to, length, rest, _string) do
     case rest do
       <<body::size(length)-binary, "\r\n", rest::binary>> ->
         {:ok, {:msg, subject, sid, reply_to, body}, rest}
 
       _other ->
-        {:error, string}
+        # Header parsed, but body bytes not all here yet.
+        # Return the partial body bytes already received so the caller can accumulate
+        # subsequent chunks in an iolist without re-copying the growing buffer.
+        {:pending, {:msg, subject, sid, reply_to, length, rest, byte_size(rest)}}
     end
   end
 
-  def finish_hmsg(subject, sid, reply_to, header_length, total_length, rest, string) do
+  def finish_hmsg(subject, sid, reply_to, header_length, total_length, rest, _string) do
     payload_length = total_length - header_length
 
     case rest do
@@ -199,7 +253,8 @@ defmodule Gnat.Parsec do
         {:ok, {:hmsg, subject, sid, reply_to, status, description, headers, payload}, rest}
 
       _other ->
-        {:error, string}
+        {:pending,
+         {:hmsg, subject, sid, reply_to, header_length, total_length, rest, byte_size(rest)}}
     end
   end
 end

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -202,16 +202,16 @@ defmodule Gnat.Parsec do
   def parse_command(string) do
     case command(string) do
       {:ok, [:msg, subject, sid, length], rest, _, _, _} ->
-        finish_msg(subject, sid, nil, length, rest, string)
+        finish_msg(subject, sid, nil, length, rest)
 
       {:ok, [:msg, subject, sid, reply_to, length], rest, _, _, _} ->
-        finish_msg(subject, sid, reply_to, length, rest, string)
+        finish_msg(subject, sid, reply_to, length, rest)
 
       {:ok, [:hmsg, subject, sid, header_length, total_length], rest, _, _, _} ->
-        finish_hmsg(subject, sid, nil, header_length, total_length, rest, string)
+        finish_hmsg(subject, sid, nil, header_length, total_length, rest)
 
       {:ok, [:hmsg, subject, sid, reply_to, header_length, total_length], rest, _, _, _} ->
-        finish_hmsg(subject, sid, reply_to, header_length, total_length, rest, string)
+        finish_hmsg(subject, sid, reply_to, header_length, total_length, rest)
 
       {:ok, [atom], rest, _, _, _} ->
         {:ok, atom, rest}
@@ -259,7 +259,7 @@ defmodule Gnat.Parsec do
     {:error, "Could not parse status line prefix"}
   end
 
-  def finish_msg(subject, sid, reply_to, length, rest, _string) do
+  def finish_msg(subject, sid, reply_to, length, rest) do
     case rest do
       <<body::size(length)-binary, "\r\n", rest::binary>> ->
         {:ok, {:msg, subject, sid, reply_to, body}, rest}
@@ -272,7 +272,7 @@ defmodule Gnat.Parsec do
     end
   end
 
-  def finish_hmsg(subject, sid, reply_to, header_length, total_length, rest, _string) do
+  def finish_hmsg(subject, sid, reply_to, header_length, total_length, rest) do
     payload_length = total_length - header_length
 
     case rest do

--- a/test/gnat/parsec_test.exs
+++ b/test/gnat/parsec_test.exs
@@ -129,6 +129,44 @@ defmodule Gnat.ParsecTest do
     assert parser_state.pending == nil
   end
 
+  test "parsing partial HMSG — body split across multiple TCP chunks" do
+    # Chunk 1: full HMSG header arrives, but only part of the body ("PAY")
+    # header_length=23 covers "NATS/1.0\r\nHeader: X\r\n\r\n", total_length=30 (23 + 7 "PAYLOAD")
+    chunk1 = "HMSG SUBJECT 1 REPLY 23 30\r\nNATS/1.0\r\nHeader: X\r\n\r\nPAY"
+
+    {state1, commands1} = Parsec.new() |> Parsec.parse(chunk1)
+
+    assert commands1 == []
+    assert state1.partial == nil
+    assert {:hmsg, "SUBJECT", 1, "REPLY", 23, 30, _chunks, _have} = state1.pending
+
+    # Chunk 2: remaining body bytes arrive, completing the message
+    chunk2 = "LOAD\r\n"
+
+    {state2, [parsed]} = Parsec.parse(state1, chunk2)
+
+    assert state2.pending == nil
+    assert state2.partial == nil
+    assert parsed == {:hmsg, "SUBJECT", 1, "REPLY", nil, nil, [{"header", "X"}], "PAYLOAD"}
+  end
+
+  test "parsing partial HMSG — body split across three TCP chunks" do
+    # Verifies that the iolist accumulation works across more than two chunks
+    chunk1 = "HMSG SUBJECT 1 23 30\r\nNATS/1.0\r\nHeader: X\r\n\r\nPA"
+    chunk2 = "YLO"
+    chunk3 = "AD\r\n"
+
+    {state1, []} = Parsec.new() |> Parsec.parse(chunk1)
+    assert {:hmsg, "SUBJECT", 1, nil, 23, 30, _chunks, _have} = state1.pending
+
+    {state2, []} = Parsec.parse(state1, chunk2)
+    assert {:hmsg, "SUBJECT", 1, nil, 23, 30, _chunks, _have} = state2.pending
+
+    {state3, [parsed]} = Parsec.parse(state2, chunk3)
+    assert state3.pending == nil
+    assert parsed == {:hmsg, "SUBJECT", 1, nil, nil, nil, [{"header", "X"}], "PAYLOAD"}
+  end
+
   test "parsing INFO message" do
     {parser_state, [parsed_message]} =
       Parsec.new()

--- a/test/gnat/parsec_test.exs
+++ b/test/gnat/parsec_test.exs
@@ -129,7 +129,7 @@ defmodule Gnat.ParsecTest do
     assert parser_state.pending == nil
   end
 
-  test "parsing partial HMSG — body split across multiple TCP chunks" do
+  test "parsing partial HMSG with body split across multiple TCP chunks" do
     # Chunk 1: full HMSG header arrives, but only part of the body ("PAY")
     # header_length=23 covers "NATS/1.0\r\nHeader: X\r\n\r\n", total_length=30 (23 + 7 "PAYLOAD")
     chunk1 = "HMSG SUBJECT 1 REPLY 23 30\r\nNATS/1.0\r\nHeader: X\r\n\r\nPAY"
@@ -150,7 +150,7 @@ defmodule Gnat.ParsecTest do
     assert parsed == {:hmsg, "SUBJECT", 1, "REPLY", nil, nil, [{"header", "X"}], "PAYLOAD"}
   end
 
-  test "parsing partial HMSG — body split across three TCP chunks" do
+  test "parsing partial HMSG with body split across three TCP chunks" do
     # Verifies that the iolist accumulation works across more than two chunks
     chunk1 = "HMSG SUBJECT 1 23 30\r\nNATS/1.0\r\nHeader: X\r\n\r\nPA"
     chunk2 = "YLO"
@@ -165,6 +165,31 @@ defmodule Gnat.ParsecTest do
     {state3, [parsed]} = Parsec.parse(state2, chunk3)
     assert state3.pending == nil
     assert parsed == {:hmsg, "SUBJECT", 1, nil, nil, nil, [{"header", "X"}], "PAYLOAD"}
+  end
+
+  test "malformed MSG termination raises a descriptive error" do
+    # Put parser into pending state: body is declared as 4 bytes but only 4 bytes
+    # arrive in the first chunk, so 4 < 4 + 2 = 6 and we wait for more data.
+    {state, []} = Parsec.new() |> Parsec.parse("MSG topic 1 4\r\ntest")
+    assert {:msg, "topic", 1, nil, 4, _chunks, _have} = state.pending
+
+    # Second chunk brings the byte count to >= 6 but uses "!!" instead of \r\n.
+    assert_raise RuntimeError, ~r/malformed MSG termination/, fn ->
+      Parsec.parse(state, "!!\r\n")
+    end
+  end
+
+  test "malformed HMSG termination raises a descriptive error" do
+    # header_length=23 ("NATS/1.0\r\nHeader: X\r\n\r\n"), total_length=30 (23 + 7 for "PAYLOAD")
+    # Chunk 1: header line + 26 bytes of payload section not enough (26 < 32)
+    chunk1 = "HMSG SUBJECT 1 23 30\r\nNATS/1.0\r\nHeader: X\r\n\r\nPAY"
+    {state, []} = Parsec.new() |> Parsec.parse(chunk1)
+    assert {:hmsg, "SUBJECT", 1, nil, 23, 30, _chunks, _have} = state.pending
+
+    # Chunk 2: brings byte count to >= 32, but terminates with "!!" instead of \r\n.
+    assert_raise RuntimeError, ~r/malformed HMSG termination/, fn ->
+      Parsec.parse(state, "LOAD!!\r\n")
+    end
   end
 
   test "parsing INFO message" do

--- a/test/gnat/parsec_test.exs
+++ b/test/gnat/parsec_test.exs
@@ -117,7 +117,8 @@ defmodule Gnat.ParsecTest do
       Parsec.new() |> Parsec.parse("PING\r\nMSG topic 11 4\r\nOH")
 
     assert parsed_message == :ping
-    assert parser_state.partial == "MSG topic 11 4\r\nOH"
+    assert parser_state.partial == nil
+    assert parser_state.pending == {:msg, "topic", 11, nil, 4, "OH", 2}
 
     {parser_state, [msg1, msg2]} =
       Parsec.parse(parser_state, "AI\r\nMSG topic 11 3\r\nWAT\r\nMSG topic")
@@ -125,6 +126,7 @@ defmodule Gnat.ParsecTest do
     assert msg1 == {:msg, "topic", 11, nil, "OHAI"}
     assert msg2 == {:msg, "topic", 11, nil, "WAT"}
     assert parser_state.partial == "MSG topic"
+    assert parser_state.pending == nil
   end
 
   test "parsing INFO message" do


### PR DESCRIPTION
First, thanks for creating this great library for Elixir!

### Why this PR

We need to handle large payloads (> 8MB), and we noticed a significant lag as the payload increased.

*Before this PR*
```
1 MB  payload:  21.86 ms latency
16 MB payload: 2.6 seconds latency
32 MB payload: 9.9 seconds latency
```

*After this PR*
```
1 MB  payload:  2.54 ms latency
16 MB payload: 15.05 ms latency
32 MB payload: 29 ms latency
```

'latency': delta t between pushing to NATS server and receiving the message back in the subscribed process' inbox.

### Explanation

When a NATS message body spans multiple TCP segments, the parser was
accumulating data with `partial <> string` on every incoming chunk.
This means a lot of copies, and the more chunks, the more copies needed.

### Fix
This PR introduces a `pending` field on `Parsec` that tracks the
already-decoded MSG/HMSG header metadata and body bytes received so
far as an iolist. Subsequent chunks are appended to the iolist in O(1)
with no copying. `iolist_to_binary/1` is called exactly once, only
when enough bytes have arrived to complete the message body.

This reduces large-payload receive latency from O(n²) to O(n) and
eliminates the main source of multi-second delays observed with
payloads above ~8 MB.

### Benchmarks
I ran all benchmarks but the client/server ones, and saw improvements overall.
I am happy to provide more details, but I am not sure what's the best way to compare or provide before-after.
I'm glad to receive feedback and provide more details.

Thanks!

(Co-authored with Cursor)