### PR TITLE
Add client name to NATS CONNECT settings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,10 +19,6 @@ jobs:
     strategy:
       matrix:
         pair:
-          - otp: "25"
-            elixir: "1.14"
-            nats: "2.10.24"
-
           - otp: "26"
             elixir: "1.16"
             nats: "2.10.24"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.16
+
+* Add support for the `name` connection setting, which is reported to NATS
+  monitoring endpoints. Contributed by @ahamez in #227
+* Require Elixir 1.16+. Elixir 1.14 and 1.15 are no longer supported (both are
+  past their upstream maintenance window). The CI matrix now runs on Elixir
+  1.16 through 1.19 and Erlang/OTP 26 through 28.
+
 ## 1.15
 
 * `PullConsumer` now requests an `idle_heartbeat` (defaults to half of

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -50,6 +50,7 @@ defmodule Gnat do
   * `tls` - If the server should use a TLS connection
   * `inbox_prefix` - Prefix to use for the message inbox of this connection
   * `no_responders` - Enable the no responders behavior (see `Gnat.request/4`)
+  * `name` - The client name reported by NATS monitoring endpoints
   """
   @type connection_settings :: %{
           optional(:connection_timeout) => non_neg_integer(),
@@ -60,7 +61,8 @@ defmodule Gnat do
           optional(:ssl_opts) => list(),
           optional(:tcp_opts) => list(),
           optional(:tls) => boolean(),
-          optional(:no_responders) => boolean()
+          optional(:no_responders) => boolean(),
+          optional(:name) => binary()
         }
 
   @typedoc """

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -22,6 +22,7 @@ defmodule Gnat.Handshake do
     |> negotiate_auth(server_settings, user_settings, auth_required)
     |> negotiate_headers(server_settings, user_settings)
     |> negotiate_no_responders(server_settings, user_settings)
+    |> negotiate_name(user_settings)
   end
 
   defp perform_handshake(tcp, user_settings) do
@@ -111,6 +112,14 @@ defmodule Gnat.Handshake do
   end
 
   defp negotiate_no_responders(settings, _server_settings, _user_settings) do
+    settings
+  end
+
+  defp negotiate_name(settings, %{name: name}) when is_binary(name) do
+    Map.put(settings, :name, name)
+  end
+
+  defp negotiate_name(settings, _user_settings) do
     settings
   end
 

--- a/lib/gnat/parsec.ex
+++ b/lib/gnat/parsec.ex
@@ -127,7 +127,7 @@ defmodule Gnat.Parsec do
 
       {:complete, binary} ->
         case binary do
-          <<body::binary-size(length), "\r\n", rest::binary>> ->
+          <<body::binary-size(^length), "\r\n", rest::binary>> ->
             {new_partial, new_pending, more} = parse_commands(rest, [])
 
             {%{state | partial: new_partial, pending: new_pending},
@@ -157,8 +157,8 @@ defmodule Gnat.Parsec do
         payload_length = total_length - header_length
 
         case binary do
-          <<headers_bin::binary-size(header_length), payload::binary-size(payload_length), "\r\n",
-            rest::binary>> ->
+          <<headers_bin::binary-size(^header_length), payload::binary-size(^payload_length),
+            "\r\n", rest::binary>> ->
             {:ok, status, description, headers} = parse_headers(headers_bin)
             {new_partial, new_pending, more} = parse_commands(rest, [])
 
@@ -261,7 +261,7 @@ defmodule Gnat.Parsec do
 
   def finish_msg(subject, sid, reply_to, length, rest) do
     case rest do
-      <<body::size(length)-binary, "\r\n", rest::binary>> ->
+      <<body::size(^length)-binary, "\r\n", rest::binary>> ->
         {:ok, {:msg, subject, sid, reply_to, body}, rest}
 
       _other ->
@@ -276,7 +276,7 @@ defmodule Gnat.Parsec do
     payload_length = total_length - header_length
 
     case rest do
-      <<headers::size(header_length)-binary, payload::size(payload_length)-binary, "\r\n",
+      <<headers::size(^header_length)-binary, payload::size(^payload_length)-binary, "\r\n",
         rest::binary>> ->
         {:ok, status, description, headers} = parse_headers(headers)
         {:ok, {:hmsg, subject, sid, reply_to, status, description, headers, payload}, rest}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Gnat.Mixfile do
     [
       app: :gnat,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/gnat/handshake_test.exs
+++ b/test/gnat/handshake_test.exs
@@ -86,5 +86,16 @@ defmodule Gnat.HandshakeTest do
       assert Map.has_key?(result, :jwt)
       assert result[:protocol] == 1
     end
+
+    test "includes the client name" do
+      assert %{name: "some-name"} = Handshake.negotiate_settings(%{}, %{name: "some-name"})
+    end
+
+    test "does not include a non-binary client name" do
+      refute Map.has_key?(
+               Handshake.negotiate_settings(%{}, %{name: :non_binary_client_name}),
+               :name
+             )
+    end
   end
 end

--- a/test/jetstream/api/object_test.exs
+++ b/test/jetstream/api/object_test.exs
@@ -4,7 +4,6 @@ defmodule Gnat.Jetstream.API.ObjectTest do
   import Gnat.Jetstream.API.Util, only: [nuid: 0]
 
   @moduletag with_gnat: :gnat
-  @changelog_path Path.join([Path.dirname(__DIR__), "..", "..", "CHANGELOG.md"])
   @readme_path Path.join([Path.dirname(__DIR__), "..", "..", "README.md"])
 
   describe "create_bucket/3" do
@@ -143,11 +142,11 @@ defmodule Gnat.Jetstream.API.ObjectTest do
     test "overwriting a file" do
       bucket = nuid()
       assert {:ok, %{config: _stream}} = Object.create_bucket(:gnat, bucket)
-      assert {:ok, _} = put_filepath(@readme_path, bucket, "WAT")
-      size_after_readme = stream_byte_size(bucket)
-      assert {:ok, _} = put_filepath(@changelog_path, bucket, "WAT")
-      size_after_changelog = stream_byte_size(bucket)
-      assert size_after_changelog < size_after_readme
+      assert {:ok, _} = put_binary(:binary.copy("a", 20_000), bucket, "WAT")
+      size_after_large = stream_byte_size(bucket)
+      assert {:ok, _} = put_binary(:binary.copy("a", 1_000), bucket, "WAT")
+      size_after_small = stream_byte_size(bucket)
+      assert size_after_small < size_after_large
       assert {:ok, [meta]} = Object.list(:gnat, bucket)
       assert meta.name == "WAT"
 
@@ -255,6 +254,11 @@ defmodule Gnat.Jetstream.API.ObjectTest do
 
   defp put_filepath(path, bucket, name) do
     {:ok, io} = File.open(path, [:read])
+    Object.put(:gnat, bucket, name, io)
+  end
+
+  defp put_binary(binary, bucket, name) do
+    {:ok, io} = StringIO.open(binary)
     Object.put(:gnat, bucket, name, io)
   end
 


### PR DESCRIPTION
Hello, 

This PR adds the support of the [name parameter](https://docs.nats.io/reference/reference-protocols/nats-protocol#connect) when sending CONNECT.

I took the opportunity to silence a few warnings about variables pinning in pattern matching.